### PR TITLE
Create RAG DB content for lesson 1 and reusable exercises

### DIFF
--- a/data/rag_database/exercises/REUSABILITY_GUIDE.md
+++ b/data/rag_database/exercises/REUSABILITY_GUIDE.md
@@ -1,0 +1,272 @@
+---
+title: Exercise Template Reusability Guide
+purpose: Explain how to adapt exercise templates for different grammar points
+---
+
+# Exercise Template Reusability Guide
+
+## Overview
+
+Most exercise templates in this directory are **reusable** across multiple grammar points. This guide explains how Agent 3 should adapt each template for different lessons.
+
+---
+
+## Reusability Classification
+
+### ✅ Fully Reusable (Works for ANY grammar point)
+
+These templates work with minimal adaptation:
+
+1. **sorting_gender_categorization.md**
+   - **Reusable for**: verb tense, noun number (singular/plural), adjective agreement, sentence types
+   - **How to adapt**: Change category names (masculine/feminine → past/present → singular/plural)
+   - **Example**: "Sort these verbs: past tense | present tense"
+
+2. **pattern_recognition_gender.md**
+   - **Reusable for**: any binary or ternary classification
+   - **How to adapt**: Change the target pattern to identify
+   - **Example**: "Select all past tense verbs", "Select all plural nouns"
+
+3. **error_correction_definite_article.md**
+   - **Reusable for**: any spelling/form errors
+   - **How to adapt**: Change error types (ال errors → verb conjugation errors → pronoun errors)
+   - **Example**: "Fix the verb conjugation: أنا يكتب → أنا أكتب"
+
+4. **transformation_chain_definite_article.md**
+   - **Reusable for**: any A → B transformation
+   - **How to adapt**: Change transformation rule
+   - **Examples**:
+     - Singular → Plural: كِتَابٌ → كُتُبٌ → كِتَابٌ
+     - Present → Past: يَكْتُبُ → كَتَبَ → يَكْتُبُ
+     - Verb conjugation: أَكْتُبُ → تَكْتُبُ → يَكْتُبُ
+
+5. **cloze_grammar_rules.md**
+   - **Reusable for**: ANY grammar rule explanation
+   - **How to adapt**: Change the rule text, keep the fill-in-blank format
+   - **Example**: "Verbs in past tense end with _____"
+
+6. **paradigm_table_combined.md**
+   - **Reusable for**: ANY systematic forms (verb conjugations, noun declensions)
+   - **How to adapt**: Change table headers and fill patterns
+   - **Examples**:
+     - Verb conjugation table: I/you/he/she × singular/plural
+     - Noun case table: nominative/accusative/genitive × singular/plural
+
+7. **sentence_level_combined.md**
+   - **Reusable for**: ANY grammar in context
+   - **How to adapt**: Change error types to match target grammar
+   - **Example**: "Fix the verb agreement: أنا يكتب في الكتاب"
+
+8. **multiple_choice_error_identification.md**
+   - **Reusable for**: ANY error types
+   - **How to adapt**: Change error patterns
+   - **Example**: "Which verb is conjugated incorrectly?"
+
+9. **noun_adjective_agreement.md** (NEW)
+   - **Reusable for**: verb-subject agreement, pronoun agreement, demonstrative agreement
+   - **How to adapt**: Change what must agree (adjective → verb → pronoun)
+   - **Example**: "Complete: أنا _____ (to write)" → أنا أكْتُبُ
+
+---
+
+### ⚠️ Partially Reusable (Needs significant adaptation)
+
+10. **dictation_combined_gender_definite.md**
+    - **Current**: Tests gender + definiteness simultaneously
+    - **Reusable for**: Any two combined grammar points
+    - **How to adapt**: Change the two dimensions being tested
+    - **Example**: "Write: 'I wrote' (past tense, first person)" → كَتَبْتُ
+
+---
+
+### ❌ Lesson-Specific (Not easily reusable)
+
+11. **fill_in_blank_gender.md**
+    - Highly specific to gender identification (is this masculine or feminine?)
+    - Could be adapted for other binary choices but structure is very specialized
+
+12. **translation_definite_article.md**
+    - Very specific to adding/removing ال
+    - Hard to generalize beyond this transformation
+
+**Note**: Even "non-reusable" templates can inspire similar templates for other grammar points.
+
+---
+
+## How Agent 3 Should Use This Guide
+
+### Step 1: Identify Grammar Point
+```
+Input: lesson_number=2, grammar_point="verb_conjugation_present"
+```
+
+### Step 2: Select Compatible Templates
+```
+Compatible templates:
+- sorting → "Sort by person (I/you/he)"
+- pattern_recognition → "Select all first-person verbs"
+- error_correction → "Fix conjugation errors"
+- transformation_chain → "أَكْتُبُ → تَكْتُبُ → ___"
+- cloze → "First person singular verbs start with _____"
+- paradigm_table → "Complete verb conjugation table"
+- sentence_level → "Fix: أنا يكتب"
+```
+
+### Step 3: Adapt Template Parameters
+```python
+# Example: Adapting sorting template for verb tense
+template = "sorting_gender_categorization.md"
+adaptations = {
+    "category_1": "past_tense",
+    "category_2": "present_tense",
+    "vocabulary_pool": verb_vocabulary,
+    "question_prompt": "Sort these verbs into past and present tense:"
+}
+```
+
+### Step 4: Generate Exercise
+Use adapted parameters to fill template and generate questions.
+
+---
+
+## Template Adaptation Parameters
+
+### For Sorting Templates
+```yaml
+parameters:
+  - category_names: [list of categories to sort into]
+  - category_count: 2 or 3
+  - vocabulary_pool: items to sort
+  - identification_rule: how to determine category (e.g., "ends in ة" → "ends in ت")
+```
+
+### For Transformation Templates
+```yaml
+parameters:
+  - transformation_rule: description of A → B
+  - forward_example: كِتَابٌ → الْكِتَابُ
+  - backward_example: الْكِتَابُ → كِتَابٌ
+  - rule_name: "add ال" | "conjugate for first person" | etc.
+```
+
+### For Agreement Templates
+```yaml
+parameters:
+  - element_1: noun | verb | pronoun
+  - element_2: adjective | subject | verb
+  - agreement_dimensions: [gender, definiteness] | [person, number] | etc.
+  - rules: list of what must match
+```
+
+### For Error Correction Templates
+```yaml
+parameters:
+  - error_types: [list of common errors for this grammar point]
+  - correct_forms: examples of correct usage
+  - error_patterns: regex or description of errors to introduce
+```
+
+---
+
+## Reusability Matrix
+
+| Template | Gender | Def/Indef | Verb Tense | Verb Conj | Noun Plural | Adjective | Pronouns |
+|----------|--------|-----------|------------|-----------|-------------|-----------|----------|
+| Sorting | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Pattern Recognition | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Error Correction | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Transformation Chain | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| Cloze Rules | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Paradigm Table | ✗ | ✓ | ✗ | ✓ | ✓ | ✗ | ✓ |
+| Sentence Level | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Multiple Choice Error | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Agreement | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ |
+| Dictation Combined | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+**Legend:**
+- ✓ = Easily reusable for this grammar point
+- ✗ = Not applicable or requires major restructuring
+
+---
+
+## Future Grammar Points & Templates
+
+### Lesson 2: Subject Pronouns & Nominal Sentences
+**Reusable templates:**
+- Sorting → "Sort pronouns by person (1st/2nd/3rd)"
+- Pattern Recognition → "Select all second-person pronouns"
+- Agreement → "Match pronoun to noun gender"
+- Sentence Level → "Fix: هُوَ طَالِبَةٌ (wrong gender)"
+
+### Lesson 3: Adjective Agreement
+**Reusable templates:**
+- noun_adjective_agreement.md (already designed for this!)
+- Error Correction → Fix gender/definiteness mismatches
+- Paradigm Table → Complete all forms (m/f × def/indef)
+
+### Lesson 4: Present Tense Verbs
+**Reusable templates:**
+- Transformation Chain → I write → you write → he writes
+- Paradigm Table → Verb conjugation chart
+- Error Correction → Fix conjugation errors
+- Cloze → "First person verbs start with _____"
+
+### Lesson 5: Past Tense Verbs
+**Reusable templates:**
+- Sorting → Sort verbs by tense (past/present)
+- Transformation Chain → Present → Past
+- Sentence Level → Fix tense in context
+
+---
+
+## Agent 3 Implementation Strategy
+
+### When generating exercises:
+
+1. **Load grammar point** from lesson metadata
+2. **Check reusability guide** to find compatible templates
+3. **Load template** with parameter adaptations
+4. **Parse template rules** (replace gender with tense, etc.)
+5. **Generate questions** using adapted vocabulary and rules
+6. **Output exercises** with grammar-point-specific content
+
+### Example code structure:
+```python
+def adapt_template(template_name, grammar_point, vocabulary):
+    """Adapt a reusable template for a specific grammar point."""
+    
+    template = load_template(template_name)
+    adaptations = ADAPTATION_RULES[grammar_point]
+    
+    # Replace category names
+    template = template.replace(adaptations["old_category"], adaptations["new_category"])
+    
+    # Replace vocabulary pool
+    template.vocabulary_pool = vocabulary
+    
+    # Generate questions using adapted template
+    questions = generate_questions(template, count=5)
+    
+    return questions
+```
+
+---
+
+## Benefits of Reusable Templates
+
+1. **Consistency**: Same exercise structure across lessons
+2. **Efficiency**: Don't reinvent the wheel for each grammar point
+3. **Proven patterns**: Templates that work well for gender will work for tense
+4. **Easier maintenance**: Fix a bug once, applies to all lessons
+5. **Faster development**: Create new lessons without creating new exercise types
+
+---
+
+## When to Create NEW Templates
+
+Create a new template only when:
+- Existing templates can't be adapted (e.g., dual vs. plural specific exercise)
+- Grammar point has unique structure (e.g., idafa construction)
+- Exercise type is fundamentally different (e.g., audio comprehension)
+
+Otherwise, prefer adapting existing templates using this guide.

--- a/data/rag_database/exercises/REUSABILITY_GUIDE.md
+++ b/data/rag_database/exercises/REUSABILITY_GUIDE.md
@@ -65,7 +65,7 @@ These templates work with minimal adaptation:
 9. **noun_adjective_agreement.md** (NEW)
    - **Reusable for**: verb-subject agreement, pronoun agreement, demonstrative agreement
    - **How to adapt**: Change what must agree (adjective → verb → pronoun)
-   - **Example**: "Complete: أنا _____ (to write)" → أنا أكْتُبُ
+   - **Example**: "Complete: أنا _____ (to write)" → أنا أَكْتُبُ
 
 ---
 

--- a/data/rag_database/exercises/cloze_grammar_rules.md
+++ b/data/rag_database/exercises/cloze_grammar_rules.md
@@ -1,0 +1,332 @@
+---
+exercise_type: cloze
+grammar_point: grammar_rule_completion
+difficulty: beginner
+lesson_number: 1
+target_skill: articulating_grammar_rules
+reusable: true
+reusable_for: [ALL_GRAMMAR_POINTS]
+adaptation_params:
+  - rule_text: The grammar rule statement
+  - key_terms: Terms to blank out
+  - acceptable_answers: List of synonyms/variations accepted
+  - word_bank: Optional list of choices (for beginner level)
+---
+
+# Cloze Exercise: Grammar Rule Completion
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Articulate grammar rules in their own words
+2. Recall key terminology (tanween, ة, ال)
+3. Explain transformation processes
+4. Demonstrate conceptual understanding (not just application)
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Complete the following grammar rule by filling in the blanks:
+
+{rule_with_blanks}
+```
+
+**Answer Format:**
+```json
+{
+  "blank_1": "answer text",
+  "blank_2": "answer text",
+  ...
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `grammar_topic`: "gender" | "definite_article" | "tanween"
+- `difficulty`: beginner | intermediate | advanced
+- `blank_count`: Number of blanks per rule (1-4)
+
+### Question Types by Topic
+
+**Gender Rules:**
+1. "Words ending in _____ are feminine"
+2. "The _____ (taa marbuuta) is the marker of feminine gender"
+3. "If a noun does not end in ة, it is usually _____"
+
+**Definite Article Rules:**
+1. "To make a noun definite, add _____ at the beginning"
+2. "When you add ال, the tanween _____"
+3. "Definite nouns have _____ and no tanween"
+4. "Indefinite nouns have _____ and no ال"
+
+**Tanween Rules:**
+1. "Tanween is the _____ vowel mark that indicates indefinite"
+2. "When ال is added, tanween _____ and becomes a single vowel"
+3. "The most common tanween for beginners is _____ (dammatan)"
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Single Blank - Gender)
+**Question:** Complete the grammar rule:
+
+Words ending in _____ (taa marbuuta) are feminine nouns.
+
+**Correct Answer:**
+```json
+{
+  "blank_1": "ة"
+}
+```
+
+**Acceptable Alternatives:**
+- "ة" (exact)
+- "ta marbuta" (transliteration)
+- "taa marbuuta"
+- "the letter ة"
+
+---
+
+### Question 2 (Single Blank - Definite Article)
+**Question:** Complete the grammar rule:
+
+To make a noun definite, add _____ at the beginning and remove the tanween.
+
+**Correct Answer:**
+```json
+{
+  "blank_1": "ال"
+}
+```
+
+**Acceptable Alternatives:**
+- "ال" (exact)
+- "al" (transliteration)
+- "al-" (with hyphen)
+- "the definite article"
+- "the article ال"
+
+---
+
+### Question 3 (Two Blanks - Transformation)
+**Question:** Complete the grammar rule:
+
+When you add _____ to a noun, the tanween (ٌ) _____ and becomes a single damma (ُ).
+
+**Correct Answer:**
+```json
+{
+  "blank_1": "ال",
+  "blank_2": "disappears"
+}
+```
+
+**Acceptable Alternatives for blank_2:**
+- "disappears"
+- "is removed"
+- "goes away"
+- "is dropped"
+- "becomes a single vowel"
+
+---
+
+### Question 4 (Three Blanks - Complete Rule)
+**Question:** Complete the grammar rule:
+
+Indefinite nouns end with _____ (double vowel). Definite nouns have _____ at the beginning and _____ tanween.
+
+**Correct Answer:**
+```json
+{
+  "blank_1": "tanween",
+  "blank_2": "ال",
+  "blank_3": "no"
+}
+```
+
+**Acceptable Alternatives:**
+- blank_1: "tanween" | "ٌ" | "double vowel" | "dammatan"
+- blank_2: "ال" | "al" | "the definite article"
+- blank_3: "no" | "without" | "0" | "not"
+
+---
+
+### Question 5 (Multiple Choice Cloze - Intermediate)
+**Question:** Complete the grammar rule by selecting the correct word:
+
+When ال is added to كِتَابٌ, the tanween _____ and the word becomes الْكِتَابُ.
+
+Options:
+a) remains
+b) disappears
+c) doubles
+d) moves
+
+**Correct Answer:**
+```json
+{
+  "answer": "b",
+  "explanation": "Tanween disappears when ال is added because definite nouns cannot have tanween"
+}
+```
+
+---
+
+### Question 6 (Complex Rule - Advanced)
+**Question:** Complete the complex grammar rule:
+
+To transform an indefinite noun to definite: (1) add _____ to the _____, (2) remove the _____, and (3) replace it with a single _____.
+
+**Correct Answer:**
+```json
+{
+  "blank_1": "ال",
+  "blank_2": "beginning",
+  "blank_3": "tanween",
+  "blank_4": "damma"
+}
+```
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Meaning is accurate (accepts synonyms)
+- Arabic text is exact (if Arabic required)
+- Technical terms are correct (tanween, ال, ة)
+- Answer fits grammatically in the blank
+
+**Flexible Grading:**
+- Accept transliteration for Arabic terms (ال = "al")
+- Accept synonyms ("disappears" = "is removed" = "goes away")
+- Accept descriptive answers ("the taa marbuuta letter" = "ة")
+- Accept abbreviations if standard ("def." = "definite")
+
+**Common Student Errors:**
+- Wrong terminology (calling ة "feminine marker" instead of "taa marbuuta") → Partially correct, provide correct term
+- Reversed logic ("add tanween" instead of "remove tanween") → Incorrect, review rule
+- Vague answers ("changes" instead of "disappears") → Partially correct, request specificity
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- 1-2 blanks per rule
+- Provide word bank with options
+- Simple sentence structure
+- Focus on key terms only (ة, ال, tanween)
+
+**Intermediate (Lessons 2-3):**
+- 2-3 blanks per rule
+- No word bank (free recall)
+- More complex sentences
+- Combine multiple concepts in one rule
+
+**Advanced (Lessons 4+):**
+- 3-4 blanks per rule
+- Multi-sentence rules
+- Require technical terminology
+- Test edge cases and exceptions
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand cloze patterns
+2. **Select grammar rule** from lesson content
+3. **Determine key terms to blank out** (aim for meaningful blanks)
+4. **Generate question** with blanks marked as _____
+5. **Output JSON**:
+```json
+{
+  "question": "Complete the grammar rule by filling in the blanks:",
+  "rule_text": "To make a noun definite, add _____ at the beginning and remove the _____.",
+  "blanks": [
+    {
+      "blank_id": "blank_1",
+      "position": 1,
+      "correct_answers": ["ال", "al", "al-", "the definite article"],
+      "primary_answer": "ال"
+    },
+    {
+      "blank_id": "blank_2",
+      "position": 2,
+      "correct_answers": ["tanween", "ٌ", "double vowel", "dammatan"],
+      "primary_answer": "tanween"
+    }
+  ],
+  "explanation": "The rule is: add ال and remove tanween to make a noun definite"
+}
+```
+
+**Quality checks:**
+- [ ] Blanks are meaningful (not trivial words like "a", "the")
+- [ ] Multiple acceptable answers listed for flexibility
+- [ ] Rule is grammatically correct when completed
+- [ ] Explanation provided for learning
+- [ ] Difficulty appropriate for lesson level
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Tests conceptual understanding (not just application)
+- Requires active recall of terminology
+- Builds metalinguistic awareness (ability to talk about language)
+- Prepares students to explain rules to others
+
+**What this reveals:**
+- **Can apply but can't explain** → Rote memorization, needs deeper understanding
+- **Uses wrong terminology** → Needs vocabulary review
+- **Reverses logic** → Fundamental misconception about the rule
+- **Too vague** → Understands concept but lacks precision
+
+**Best practices:**
+- Start with simple 1-blank rules (build confidence)
+- Progress to multi-blank rules (increase challenge)
+- Provide immediate feedback with correct terminology
+- Link back to examples when student struggles with abstract rule
+
+**Word bank strategy:**
+- **Beginner**: Always provide word bank (recognition easier than recall)
+- **Intermediate**: Optional word bank (student can request if needed)
+- **Advanced**: No word bank (pure recall)
+
+**Example word banks:**
+
+**For Gender:**
+```
+Word Bank: ة, masculine, feminine, taa marbuuta, ending
+```
+
+**For Definite Article:**
+```
+Word Bank: ال, tanween, definite, indefinite, beginning, disappears, damma
+```
+
+---
+
+## UI/Implementation Notes
+
+**For web interface:**
+- Inline blanks with text boxes
+- Auto-complete suggestions for common answers
+- Highlight incorrect blanks (show which need correction)
+- Show correct answer after 2-3 attempts
+
+**For text interface:**
+- Number blanks: (1) _____ , (2) _____
+- Student responds: "1: ال, 2: tanween"
+- Accept natural language: "The answer to blank 1 is ال"

--- a/data/rag_database/exercises/dictation_combined_gender_definite.md
+++ b/data/rag_database/exercises/dictation_combined_gender_definite.md
@@ -112,7 +112,7 @@ Example: "book (masculine, definite)" → الْكِتَابُ
 
 **Correct Answer:** الطَّاوِلَةُ
 
-**Explanation:** "The table" is definite and feminine (table = طَاوِلَة ends in ة). Write: الطَّاوِلَةُ (aT-Taawilatu) with ال, no tanween.
+**Explanation:** "The table" is definite and feminine (table = طَاوِلَة ends in ة). Write: الطَّاوِلَةُ (at-taawilatu) with ال, no tanween.
 
 ---
 

--- a/data/rag_database/exercises/dictation_combined_gender_definite.md
+++ b/data/rag_database/exercises/dictation_combined_gender_definite.md
@@ -1,0 +1,259 @@
+---
+exercise_type: dictation
+grammar_point: combined_gender_and_definite
+difficulty: beginner
+lesson_number: 1
+target_skill: producing_correct_forms_from_description
+---
+
+# Dictation Exercise: Combined Gender and Definite Article
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Produce correct Arabic spelling from English description
+2. Apply both gender rules AND definite/indefinite rules simultaneously
+3. Choose correct ending (ة for feminine) AND correct markers (ال or tanween)
+4. Demonstrate full mastery of Lesson 1 concepts
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Write the Arabic for: "{english_word} ({gender}, {definiteness})"
+
+Example: "book (masculine, definite)" → الْكِتَابُ
+```
+
+**Answer Format:**
+```json
+{
+  "correct_answer": "{arabic_with_harakaat}",
+  "explanation": "Brief explanation"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with all forms (masculine/feminine, definite/indefinite)
+- `question_count`: Number of questions to generate (default: 5)
+- `difficulty`: beginner | intermediate | advanced
+
+### Question Generation Logic
+
+**For each question:**
+1. Select word from vocabulary_pool
+2. Select gender (masculine or feminine - must match word's actual gender)
+3. Select definiteness (definite or indefinite)
+4. Student must write correct Arabic form
+
+**Instruction Types:**
+- **Full description**: "school (feminine, definite)" → الْمَدْرَسَةُ
+- **Partial hints**: "the book (masculine)" → الْكِتَابُ
+- **English only**: "the school" → student must recognize feminine + definite
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Full Description)
+**Question:** Write the Arabic for:
+
+"book (masculine, definite)"
+
+**Correct Answer:** الْكِتَابُ
+
+**Explanation:** Masculine (no ة needed), definite (add ال, no tanween). Result: الْكِتَابُ (al-kitaabu)
+
+---
+
+### Question 2 (Full Description - Feminine)
+**Question:** Write the Arabic for:
+
+"school (feminine, definite)"
+
+**Correct Answer:** الْمَدْرَسَةُ
+
+**Explanation:** Feminine (ends in ة), definite (add ال, no tanween). Result: الْمَدْرَسَةُ (al-madrasatu)
+
+---
+
+### Question 3 (Indefinite)
+**Question:** Write the Arabic for:
+
+"table (feminine, indefinite)"
+
+**Correct Answer:** طَاوِلَةٌ
+
+**Explanation:** Feminine (ends in ة), indefinite (no ال, add tanween ٌ). Result: طَاوِلَةٌ (taawilatun)
+
+---
+
+### Question 4 (Natural English - Student Infers)
+**Question:** Write the Arabic for:
+
+"a pen"
+
+**Correct Answer:** قَلَمٌ
+
+**Explanation:** "A pen" is indefinite and masculine. Write: قَلَمٌ (qalamun) with tanween, no ة.
+
+---
+
+### Question 5 (Natural English - Feminine)
+**Question:** Write the Arabic for:
+
+"the table"
+
+**Correct Answer:** الطَّاوِلَةُ
+
+**Explanation:** "The table" is definite and feminine (table = طَاوِلَة ends in ة). Write: الطَّاوِلَةُ (aT-Taawilatu) with ال, no tanween.
+
+---
+
+### Question 6 (Challenge - Multiple Words)
+**Question:** Write the Arabic for both:
+
+1. "a room (feminine, indefinite)"
+2. "the office (masculine, definite)"
+
+**Correct Answer:**
+1. غُرْفَةٌ (ghurfatun)
+2. الْمَكْتَبُ (al-maktabu)
+
+**Explanation:**
+1. Feminine ending ة + indefinite tanween = غُرْفَةٌ
+2. No ة (masculine) + definite ال = الْمَكْتَبُ
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Arabic spelling is exact (including all harakaat)
+- Gender is correct (ة present/absent as needed)
+- Definiteness is correct (ال or tanween, not both)
+- All diacritical marks present
+
+**Partial Credit:**
+- Correct word but wrong definiteness (50%): e.g., كِتَابٌ instead of الْكِتَابُ
+- Correct word but wrong gender marking (30%): e.g., كِتَاب instead of كِتَابَة
+- Missing harakaat only (80%): core spelling correct but no vowel marks
+
+**Common Errors to Reject:**
+- Has both ال and tanween (conflicting markers)
+- Wrong gender (masculine word with ة, or vice versa)
+- Missing all harakaat
+- Completely wrong word
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- Full description given (gender + definiteness explicit)
+- One word at a time
+- Vocabulary from current lesson only
+- Hint: "Remember ة for feminine, ال for definite"
+
+**Intermediate (Lessons 2-3):**
+- Natural English ("a book", "the school")
+- Student must infer gender and definiteness
+- 2 words per question
+- Mix vocabulary from multiple lessons
+
+**Advanced (Lessons 4+):**
+- Sentence context: "Write: I see the big book"
+- Must produce multiple words with correct agreement
+- No hints about gender or definiteness
+- Include exception words (if taught)
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand question formats
+2. **Pull vocabulary** from cached lesson content
+3. **Select word and parameters** (gender, definiteness)
+4. **Format question** based on difficulty level
+5. **Output JSON**:
+```json
+{
+  "question": "Write the Arabic for: 'school (feminine, definite)'",
+  "target_word": "school",
+  "gender": "feminine",
+  "definiteness": "definite",
+  "correct_answer": "الْمَدْرَسَةُ",
+  "transliteration": "al-madrasatu",
+  "explanation": "Feminine (ends in ة), definite (add ال, no tanween). Result: الْمَدْرَسَةُ"
+}
+```
+
+**Quality checks:**
+- [ ] Gender specification matches word's actual gender
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Definiteness specification matches markers (ال or tanween)
+- [ ] Explanation walks through both gender and definiteness
+- [ ] All vocabulary from current or previous lessons
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Tests production (harder than recognition)
+- Integrates multiple concepts (not tested in isolation)
+- Mimics real writing tasks (producing Arabic from meaning)
+- Reveals gaps in understanding (can't fake it with multiple choice)
+
+**What this reveals:**
+- **Wrong gender marker** → Doesn't understand ة rule
+- **Wrong definiteness marker** → Confuses ال and tanween
+- **Both ال and tanween** → Doesn't understand mutual exclusivity
+- **Missing harakaat** → Not attending to full spelling
+
+**Learning progression:**
+1. **Explicit instructions**: "book (masculine, definite)" → الْكِتَابُ
+2. **Natural English**: "the book" → الْكِتَابُ
+3. **Context**: "I have the book" → الْكِتَابُ
+4. **Production**: "Write a sentence with 'the book'" → sentence with الْكِتَابُ
+
+**Common misconceptions this reveals:**
+1. Student writes كِتَابَة instead of كِتَابٌ (adds ة to masculine words)
+2. Student writes الْكِتَابٌ (keeps tanween with ال)
+3. Student writes كِتَاب (forgets all markers)
+
+**Follow-up teaching:**
+- Error type 1 → Review: "Not all words end in ة, only feminine ones"
+- Error type 2 → Review: "ال and tanween are mutually exclusive"
+- Error type 3 → Review: "Every noun needs a marker (ال or tanween)"
+
+---
+
+## Variations
+
+**Dictation with Audio (if available):**
+- Play audio: "alif-laam al-kitaabu"
+- Student writes: الْكِتَابُ
+- Tests listening + spelling
+
+**Reverse Dictation:**
+- Show Arabic: الْكِتَابُ
+- Student describes: "book, masculine, definite"
+- Tests recognition + terminology
+
+**Speed Dictation:**
+- 5 words in 60 seconds
+- Tests automaticity of form production
+
+**Peer Dictation:**
+- Student A says: "the school, feminine, definite"
+- Student B writes: الْمَدْرَسَةُ
+- Collaborative learning

--- a/data/rag_database/exercises/error_correction_definite_article.md
+++ b/data/rag_database/exercises/error_correction_definite_article.md
@@ -1,0 +1,296 @@
+---
+exercise_type: error_correction
+grammar_point: definite_article_spelling
+difficulty: beginner
+lesson_number: 1
+target_skill: identifying_and_fixing_al_tanween_errors
+reusable: true
+reusable_for: [definite_article, verb_conjugation, pronoun_forms, adjective_agreement, plural_formation]
+adaptation_params:
+  - error_types: List of error patterns for this grammar point
+  - correct_forms: Examples of correct usage
+  - error_detection_rule: How to identify the error
+---
+
+# Error Correction Exercise: Definite Article Spelling
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Identify spelling errors in definite/indefinite nouns
+2. Fix ال + tanween conflicts
+3. Add missing tanween or ال
+4. Apply definite/indefinite rules correctly
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Fix the spelling errors in these words:
+
+1. {word_with_error_1}
+2. {word_with_error_2}
+3. {word_with_error_3}
+...
+```
+
+**Answer Format:**
+```json
+{
+  "corrections": [
+    {
+      "original": "الْكِتَابٌ",
+      "corrected": "الْكِتَابُ",
+      "explanation": "Remove tanween when word has ال"
+    },
+    ...
+  ]
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with indefinite and definite forms
+- `error_count`: Number of errors to present (default: 5)
+- `error_types`: Mix of error patterns
+- `difficulty`: beginner | intermediate | advanced
+
+### Error Types
+
+**Type 1: ال + tanween conflict (most common)**
+- Error: الْكِتَابٌ (has both ال and tanween)
+- Correct: الْكِتَابُ (has ال, no tanween)
+
+**Type 2: Missing tanween on indefinite**
+- Error: كِتَاب (indefinite but no tanween)
+- Correct: كِتَابٌ (has tanween)
+
+**Type 3: Missing ال on definite**
+- Error: كِتَابُ (has damma but no ال)
+- Correct: الْكِتَابُ (has ال)
+
+**Type 4: Tanween on definite**
+- Error: الْمَدْرَسَةٌ (definite but has tanween)
+- Correct: الْمَدْرَسَةُ (no tanween)
+
+### Question Generation Logic
+
+**For each question set:**
+1. Select 5 words from vocabulary_pool
+2. Introduce 1-3 errors (mix of types)
+3. Include 2-4 correct words as distractors
+4. Student must identify and fix only the errors
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Beginner - 5 words)
+**Question:** Fix the spelling errors in these words. If a word is correct, write "correct".
+
+1. الْكِتَابٌ (al-kitaabun) - "the book"
+2. طَاوِلَةٌ (taawilatun) - "a table"
+3. مَدْرَسَة (madrasa) - "a school"
+4. الْبَيْتُ (al-baytu) - "the house"
+5. قَلَم (qalam) - "a pen"
+
+**Correct Answer:**
+```json
+{
+  "corrections": [
+    {
+      "word_number": 1,
+      "original": "الْكِتَابٌ",
+      "corrected": "الْكِتَابُ",
+      "error_type": "al_tanween_conflict",
+      "explanation": "Remove tanween (ٌ) when word has ال. Change to single damma: الْكِتَابُ"
+    },
+    {
+      "word_number": 2,
+      "original": "طَاوِلَةٌ",
+      "corrected": "correct",
+      "error_type": "none",
+      "explanation": "Indefinite feminine noun, correctly spelled with tanween"
+    },
+    {
+      "word_number": 3,
+      "original": "مَدْرَسَة",
+      "corrected": "مَدْرَسَةٌ",
+      "error_type": "missing_tanween",
+      "explanation": "Indefinite noun must have tanween. Add ٌ: مَدْرَسَةٌ"
+    },
+    {
+      "word_number": 4,
+      "original": "الْبَيْتُ",
+      "corrected": "correct",
+      "error_type": "none",
+      "explanation": "Definite noun, correctly spelled with ال and no tanween"
+    },
+    {
+      "word_number": 5,
+      "original": "قَلَم",
+      "corrected": "قَلَمٌ",
+      "error_type": "missing_tanween",
+      "explanation": "Indefinite noun must have tanween. Add ٌ: قَلَمٌ"
+    }
+  ]
+}
+```
+
+---
+
+### Question 2 (Intermediate - focus on one error type)
+**Question:** All of these words should be definite (with ال). Fix any spelling errors:
+
+1. الطَّاوِلَةٌ (aT-Taawilatu) - "the table"
+2. الْمَكْتَبُ (al-maktabu) - "the office"
+3. الْكِتَابٌ (al-kitaabun) - "the book"
+4. الْبَابُ (al-baabu) - "the door"
+5. المَدْرَسَةٌ (al-madrasatu) - "the school"
+
+**Correct Answer:**
+All words with ال + tanween must have tanween removed:
+- الطَّاوِلَةٌ → الطَّاوِلَةُ
+- الْكِتَابٌ → الْكِتَابُ
+- المَدْرَسَةٌ → الْمَدْرَسَةُ
+- الْمَكْتَبُ ✓ correct
+- الْبَابُ ✓ correct
+
+---
+
+### Question 3 (Challenge - mixed context)
+**Question:** Fix the spelling errors. Context is given to help you:
+
+1. "A book" in Arabic: كِتَابُ
+2. "The school" in Arabic: مَدْرَسَةٌ
+3. "A table" in Arabic: الطَّاوِلَةُ
+4. "The pen" in Arabic: الْقَلَمُ
+5. "A door" in Arabic: بَابٌ
+
+**Correct Answer:**
+- #1: كِتَابُ → كِتَابٌ (indefinite needs tanween)
+- #2: مَدْرَسَةٌ → الْمَدْرَسَةُ (definite needs ال, no tanween)
+- #3: الطَّاوِلَةُ → طَاوِلَةٌ (indefinite should not have ال)
+- #4: الْقَلَمُ ✓ correct (definite with ال)
+- #5: بَابٌ ✓ correct (indefinite with tanween)
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Student correctly identifies all errors
+- Student provides correct spelling fixes
+- Student correctly marks correct words as "correct" (or leaves unchanged)
+
+**Partial Credit:**
+- Identify error but fix incorrectly: 50% for that item
+- Miss an error: 0% for that item
+- Mark correct word as error: 0% for that item
+
+**Common Student Errors:**
+- Only fixing tanween, not recognizing missing ال → Review full definite article rule
+- Adding wrong vowel (kasra instead of damma) → Review harakaat placement
+- Leaving all words marked as correct → May not understand what errors look like
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- 5 words, 2-3 errors
+- Always show transliteration and English context
+- One error type at a time (e.g., all ال + tanween conflicts)
+- Clear instructions about what form is expected
+
+**Intermediate (Lessons 2-3):**
+- 6-8 words, 3-5 errors
+- Show English context only
+- Mix error types
+- Include some correct words as distractors
+
+**Advanced (Lessons 4+):**
+- 8-10 words, 4-6 errors
+- Arabic only, no context given
+- All error types mixed
+- Student must determine intended form from context
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand error patterns
+2. **Pull vocabulary** from cached lesson content
+3. **Select words and introduce errors**:
+   - 40% Type 1 (ال + tanween conflict)
+   - 30% Type 2 (missing tanween)
+   - 20% Type 4 (tanween on definite)
+   - 10% Type 3 (missing ال)
+4. **Add 2-3 correct distractors**
+5. **Output JSON**:
+```json
+{
+  "question": "Fix the spelling errors in these words. If a word is correct, write 'correct'.",
+  "words": [
+    {
+      "number": 1,
+      "arabic": "الْكِتَابٌ",
+      "transliteration": "al-kitaabun",
+      "english": "the book",
+      "has_error": true
+    },
+    {
+      "number": 2,
+      "arabic": "طَاوِلَةٌ",
+      "transliteration": "taawilatun",
+      "english": "a table",
+      "has_error": false
+    },
+    ...
+  ],
+  "corrections": [
+    {
+      "word_number": 1,
+      "original": "الْكِتَابٌ",
+      "corrected": "الْكِتَابُ",
+      "error_type": "al_tanween_conflict",
+      "explanation": "Remove tanween when word has ال. Change to single damma: الْكِتَابُ"
+    },
+    ...
+  ]
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat
+- [ ] Mix of error types appropriate for difficulty level
+- [ ] Include correct words as distractors (don't make all words errors)
+- [ ] Clear context provided for intended form (definite vs indefinite)
+- [ ] Explanations reference specific rules
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Active error detection (not passive recognition)
+- Applies rules to fix problems (higher-order thinking)
+- Builds editing/proofreading skills
+- Mimics real writing scenarios
+
+**Common misconceptions this reveals:**
+1. Student thinks tanween and ال can coexist
+2. Student doesn't recognize indefinite forms need tanween
+3. Student confuses which harakaat to use (ُ vs ٌ)
+
+**Follow-up teaching opportunities:**
+- If student misses ال + tanween conflicts → Focus on "one or the other, never both"
+- If student misses missing tanween → Focus on "indefinite always has tanween"
+- If student marks correct words as errors → Review what correct forms look like

--- a/data/rag_database/exercises/error_correction_definite_article.md
+++ b/data/rag_database/exercises/error_correction_definite_article.md
@@ -147,7 +147,7 @@ Fix the spelling errors in these words:
 ### Question 2 (Intermediate - focus on one error type)
 **Question:** All of these words should be definite (with ال). Fix any spelling errors:
 
-1. الطَّاوِلَةٌ (aT-Taawilatu) - "the table"
+1. الطَّاوِلَةٌ (at-taawilatu) - "the table"
 2. الْمَكْتَبُ (al-maktabu) - "the office"
 3. الْكِتَابٌ (al-kitaabun) - "the book"
 4. الْبَابُ (al-baabu) - "the door"

--- a/data/rag_database/exercises/fill_in_blank_gender.md
+++ b/data/rag_database/exercises/fill_in_blank_gender.md
@@ -1,0 +1,158 @@
+---
+exercise_type: fill_in_blank
+grammar_point: gender_agreement
+difficulty: beginner
+lesson_number: 1
+target_skill: identifying_noun_gender
+---
+
+# Fill-in-Blank Exercise: Gender Identification
+
+## Exercise Purpose
+
+Test student's ability to identify whether nouns are masculine or feminine by looking for the ة (taa marbuuta) ending.
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Is {noun} masculine or feminine?
+
+Options:
+a) masculine
+b) feminine
+```
+
+**Answer Format:**
+```json
+{
+  "correct_answer": "feminine" | "masculine",
+  "explanation": "Brief explanation using the ة rule"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns (with Arabic, transliteration, English, gender)
+- `question_count`: Number of questions to generate (default: 5)
+- `difficulty`: beginner | intermediate | advanced
+
+### Question Generation Logic
+
+**For each question:**
+1. Select a random noun from vocabulary_pool
+2. Format question: "Is {noun_arabic} masculine or feminine?"
+3. Provide options: a) masculine, b) feminine
+4. Generate explanation based on gender rule
+
+**Variation patterns:**
+- Mix masculine and feminine nouns (aim for ~50/50 split)
+- Include nouns with and without ة
+- Vary presentation: sometimes show transliteration, sometimes just Arabic
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1
+**Question:** Is مَدْرَسَةٌ (madrasatun) masculine or feminine?
+
+**Options:**
+a) masculine  
+b) feminine
+
+**Correct Answer:** b) feminine
+
+**Explanation:** مَدْرَسَةٌ is feminine because it ends with ة (taa marbuuta). Words ending in ة are feminine nouns.
+
+---
+
+### Question 2
+**Question:** Is كِتَابٌ (kitaabun) masculine or feminine?
+
+**Options:**
+a) masculine  
+b) feminine
+
+**Correct Answer:** a) masculine
+
+**Explanation:** كِتَابٌ is masculine because it does not end with ة. Nouns without the ة ending are typically masculine.
+
+---
+
+### Question 3
+**Question:** Is طَاوِلَةٌ masculine or feminine?
+
+**Options:**
+a) masculine  
+b) feminine
+
+**Correct Answer:** b) feminine
+
+**Explanation:** طَاوِلَةٌ is feminine. Look for the ة (taa marbuuta) at the end - it's the key indicator of feminine gender.
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Student selects the correct gender (masculine or feminine)
+- Answer must match the grammatical gender of the noun
+
+**Common Errors to Check:**
+- Student confuses ة for a different letter
+- Student identifies all nouns as masculine (not recognizing ة)
+- Student identifies all nouns as feminine (over-applying the ة rule)
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- Use only lesson vocabulary (10 words)
+- Always show transliteration
+- Use clear, common nouns
+
+**Intermediate (Lessons 2-3):**
+- Mix lesson vocabulary with previous lessons
+- Sometimes omit transliteration (test reading)
+- Include nouns without ة (test masculine default rule)
+
+**Advanced (Lessons 4+):**
+- Include exception words (feminine without ة)
+- Test in context of sentences
+- Combine with other grammar points
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand structure
+2. **Pull vocabulary** from cached lesson content
+3. **Generate 5 questions** following the format
+4. **Ensure variety**: Mix masculine/feminine, vary transliteration visibility
+5. **Output JSON**:
+```json
+[
+  {
+    "question": "Is مَدْرَسَةٌ (madrasatun) masculine or feminine?",
+    "options": ["masculine", "feminine"],
+    "correct_answer": "feminine",
+    "explanation": "مَدْرَسَةٌ is feminine because it ends with ة (taa marbuuta)."
+  },
+  ...
+]
+```
+
+**Quality checks:**
+- [ ] All questions use vocabulary from current or previous lessons
+- [ ] Mix of masculine and feminine nouns (~50/50)
+- [ ] Explanations reference the ة rule
+- [ ] All Arabic text includes proper harakaat and tanween

--- a/data/rag_database/exercises/multiple_choice_error_identification.md
+++ b/data/rag_database/exercises/multiple_choice_error_identification.md
@@ -1,0 +1,286 @@
+---
+exercise_type: multiple_choice
+grammar_point: error_identification
+difficulty: beginner
+lesson_number: 1
+target_skill: identifying_common_errors
+---
+
+# Multiple Choice Exercise: Error Identification
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Identify incorrect gender labels (feminine noun labeled as masculine)
+2. Identify incorrect definite/indefinite spelling (ال + tanween conflict)
+3. Recognize proper vs. improper Arabic spelling conventions
+
+---
+
+## Template Structure
+
+**Question Format (Gender Label Error):**
+```
+Which word is incorrectly labeled?
+
+Options:
+a) {arabic_1} ({transliteration_1}) - {label_1}
+b) {arabic_2} ({transliteration_2}) - {label_2}
+c) {arabic_3} ({transliteration_3}) - {label_3}
+```
+
+**Question Format (Spelling Error):**
+```
+Which word is spelled incorrectly?
+
+Options:
+a) {arabic_1} ({transliteration_1}) - {description_1}
+b) {arabic_2} ({transliteration_2}) - {description_2}
+c) {arabic_3} ({transliteration_3}) - {description_3}
+```
+
+**Answer Format:**
+```json
+{
+  "correct_answer": "b",
+  "explanation": "Brief explanation of why this option is incorrect"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with Arabic, transliteration, English, and gender
+- `question_count`: Number of questions to generate (default: 5)
+- `error_type`: "gender_label" | "spelling_definite" | "spelling_tanween" | "mixed"
+
+### Question Generation Logic
+
+**Error Type: gender_label**
+- Show 3 words with gender labels
+- ONE word has incorrect label (e.g., مَدْرَسَةٌ labeled "masculine" when it ends in ة)
+- Two words have correct labels (distractors)
+- Expected answer: Identify which label is wrong
+
+**Error Type: spelling_definite**
+- Show 3 words with definite article
+- ONE word has spelling error (e.g., الْكِتَابٌ has both ال and tanween)
+- Two words are spelled correctly
+- Expected answer: Identify which spelling is wrong
+
+**Error Type: spelling_tanween**
+- Show 3 words (mix of indefinite and definite)
+- ONE word missing tanween when indefinite OR has tanween when definite
+- Two words are spelled correctly
+- Expected answer: Identify which spelling is wrong
+
+**Error Type: mixed**
+- Randomly mix all three error types
+- Aim for variety across question set
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Gender Label Error)
+**Question:** Which word is incorrectly labeled?
+
+**Options:**
+a) كِتَابٌ (kitaabun) - masculine  
+b) مَدْرَسَةٌ (madrasatun) - masculine  
+c) بَابٌ (baabun) - masculine
+
+**Correct Answer:** b
+
+**Explanation:** مَدْرَسَةٌ ends in ة (taa marbuuta), so it must be feminine, not masculine. Words ending in ة are always feminine in Lesson 1.
+
+---
+
+### Question 2 (Spelling Error - Definite Article)
+**Question:** Which word is spelled incorrectly?
+
+**Options:**
+a) قَلَمٌ (qalamun) - indefinite  
+b) الْكِتَابٌ (al-kitaabun) - definite  
+c) الْبَيْتُ (al-baytu) - definite
+
+**Correct Answer:** b
+
+**Explanation:** الْكِتَابٌ has both ال (definite article) and tanween (ٌ). When a noun is definite, remove the tanween. Correct spelling: الْكِتَابُ with just damma (ُ).
+
+---
+
+### Question 3 (Gender Label Error)
+**Question:** Which word is incorrectly labeled?
+
+**Options:**
+a) طَاوِلَةٌ (taawilatun) - feminine  
+b) قَلَمٌ (qalamun) - masculine  
+c) غُرْفَةٌ (ghurfatun) - masculine
+
+**Correct Answer:** c
+
+**Explanation:** غُرْفَةٌ ends in ة (taa marbuuta), which means it's feminine, not masculine. The label should be "feminine".
+
+---
+
+### Question 4 (Spelling Error - Missing Tanween)
+**Question:** Which word is spelled incorrectly?
+
+**Options:**
+a) كِتَابٌ (kitaabun) - indefinite  
+b) بَيْت (bayt) - indefinite  
+c) طَاوِلَةٌ (taawilatun) - indefinite
+
+**Correct Answer:** b
+
+**Explanation:** بَيْت is missing tanween (ٌ). Indefinite nouns must have tanween at the end. Correct spelling: بَيْتٌ (baytun).
+
+---
+
+### Question 5 (Spelling Error - Tanween with Definite)
+**Question:** Which word is spelled incorrectly?
+
+**Options:**
+a) الْمَكْتَبُ (al-maktabu) - definite  
+b) الطَّاوِلَةٌ (aT-Taawilatu) - definite  
+c) كُرْسِيٌّ (kursiyyun) - indefinite
+
+**Correct Answer:** b
+
+**Explanation:** الطَّاوِلَةٌ has both ال (definite article) and tanween (ٌ). When ال is added, remove the tanween. Correct spelling: الطَّاوِلَةُ with just damma (ُ).
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Student selects the option with the error (a, b, or c)
+- Answer matches the expected incorrect option
+
+**Common Student Errors:**
+- Selecting a correct option (distractor) → Need more practice identifying errors
+- Not recognizing ة as feminine marker → Review gender rules
+- Not recognizing ال + tanween conflict → Review definite article rules
+- Not recognizing missing tanween → Review indefinite noun rules
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- Always show transliteration for all options
+- Use only lesson vocabulary
+- Errors are obvious (clear ة ending, clear ال + tanween conflict)
+- 3 options per question
+
+**Intermediate (Lessons 2-3):**
+- Sometimes omit transliteration (test reading)
+- Mix vocabulary from multiple lessons
+- 4 options per question (more distractors)
+- Include both masculine and feminine nouns in same question
+
+**Advanced (Lessons 4+):**
+- No transliteration (Arabic only)
+- 5 options per question
+- Combine multiple error types in one question set
+- Include exception words (feminine without ة)
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand structure
+2. **Pull vocabulary** from cached lesson content
+3. **Generate 5 questions** with variety:
+   - 2 gender label errors
+   - 2 spelling errors (definite/indefinite)
+   - 1 mixed (either type)
+4. **Ensure ONE wrong answer per question** and 2-3 correct distractors
+5. **Output JSON**:
+```json
+[
+  {
+    "question": "Which word is incorrectly labeled?",
+    "options": [
+      "a) كِتَابٌ (kitaabun) - masculine",
+      "b) مَدْرَسَةٌ (madrasatun) - masculine",
+      "c) بَابٌ (baabun) - masculine"
+    ],
+    "correct_answer": "b",
+    "explanation": "مَدْرَسَةٌ ends in ة (taa marbuuta), so it must be feminine, not masculine."
+  },
+  {
+    "question": "Which word is spelled incorrectly?",
+    "options": [
+      "a) قَلَمٌ (qalamun) - indefinite",
+      "b) الْكِتَابٌ (al-kitaabun) - definite",
+      "c) الْبَيْتُ (al-baytu) - definite"
+    ],
+    "correct_answer": "b",
+    "explanation": "الْكِتَابٌ has both ال and tanween. When definite, remove the tanween."
+  }
+  ...
+]
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] All options include transliteration (for beginner level)
+- [ ] Exactly ONE incorrect option per question
+- [ ] 2-3 correct distractors per question
+- [ ] Mix of gender and spelling error types
+- [ ] All vocabulary from current or previous lessons
+- [ ] Explanations reference the specific rule violated
+
+---
+
+## Error Pattern Reference
+
+### Gender Label Errors
+```
+❌ Wrong: مَدْرَسَةٌ (madrasatun) - masculine
+✓ Correct: مَدْرَسَةٌ (madrasatun) - feminine
+
+❌ Wrong: غُرْفَةٌ (ghurfatun) - masculine
+✓ Correct: غُرْفَةٌ (ghurfatun) - feminine
+
+Rule: If word ends in ة → FEMININE (not masculine)
+```
+
+### Spelling Errors - Definite Article + Tanween Conflict
+```
+❌ Wrong: الْكِتَابٌ (has ال + tanween)
+✓ Correct: الْكِتَابُ (has ال, no tanween)
+
+❌ Wrong: الطَّاوِلَةٌ (has ال + tanween)
+✓ Correct: الطَّاوِلَةُ (has ال, no tanween)
+
+Rule: Definite nouns (with ال) CANNOT have tanween
+```
+
+### Spelling Errors - Missing Tanween
+```
+❌ Wrong: كِتَاب (no tanween)
+✓ Correct: كِتَابٌ (with tanween ٌ)
+
+❌ Wrong: بَيْت (no tanween)
+✓ Correct: بَيْتٌ (with tanween ٌ)
+
+Rule: Indefinite nouns (without ال) MUST have tanween
+```
+
+---
+
+## Success Criteria
+
+Students should be able to:
+1. ✓ Identify when a feminine noun (ending in ة) is mislabeled as masculine
+2. ✓ Spot ال + tanween conflict (both markers present)
+3. ✓ Recognize when indefinite nouns are missing tanween
+4. ✓ Distinguish correct from incorrect spelling patterns
+5. ✓ Explain WHY an option is incorrect using grammar rules

--- a/data/rag_database/exercises/multiple_choice_error_identification.md
+++ b/data/rag_database/exercises/multiple_choice_error_identification.md
@@ -145,7 +145,7 @@ c) طَاوِلَةٌ (taawilatun) - indefinite
 
 **Options:**
 a) الْمَكْتَبُ (al-maktabu) - definite  
-b) الطَّاوِلَةٌ (aT-Taawilatu) - definite  
+b) الطَّاوِلَةٌ (at-taawilatu) - definite  
 c) كُرْسِيٌّ (kursiyyun) - indefinite
 
 **Correct Answer:** b

--- a/data/rag_database/exercises/noun_adjective_agreement.md
+++ b/data/rag_database/exercises/noun_adjective_agreement.md
@@ -1,0 +1,325 @@
+---
+exercise_type: agreement_matching
+grammar_point: noun_adjective_agreement
+difficulty: beginner
+lesson_number: 1
+target_skill: matching_gender_and_definiteness
+reusable: true
+reusable_for: [adjective_agreement, verb_subject_agreement, pronoun_agreement]
+---
+
+# Noun-Adjective Agreement Exercise
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Match adjective gender to noun gender (masculine/feminine)
+2. Match adjective definiteness to noun definiteness (ال or tanween)
+3. Apply correct word order (noun before adjective in Arabic)
+4. Produce correct noun-adjective phrases with full agreement
+
+---
+
+## Template Structure
+
+**Question Format (Type 1 - Complete the phrase):**
+```
+Complete the phrase with the correct form of the adjective:
+
+{noun} + {adjective_base} (big/small/etc.)
+
+Example: كِتَابٌ + كَبِير → ?
+```
+
+**Question Format (Type 2 - Identify error):**
+```
+Which phrase has correct agreement?
+
+a) كِتَابٌ كَبِيرَةٌ
+b) كِتَابٌ كَبِيرٌ
+c) كَبِيرٌ كِتَابٌ
+```
+
+**Question Format (Type 3 - Fix the phrase):**
+```
+Fix the agreement error:
+
+الْكِتَابُ كَبِيرٌ
+```
+
+**Answer Format:**
+```json
+{
+  "correct_phrase": "{noun} {adjective}",
+  "explanation": "Brief explanation of agreement"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with gender
+- `adjective_pool`: List of adjectives with masculine/feminine forms
+- `question_count`: Number of questions to generate (default: 5)
+- `question_type`: "complete" | "identify" | "fix" | "mixed"
+- `difficulty`: beginner | intermediate | advanced
+
+### Agreement Rules to Test
+
+**Rule 1: Gender Agreement**
+- Masculine noun → masculine adjective: كِتَابٌ كَبِيرٌ ✓
+- Feminine noun → feminine adjective: طَاوِلَةٌ كَبِيرَةٌ ✓
+- Mismatch: كِتَابٌ كَبِيرَةٌ ❌
+
+**Rule 2: Definiteness Agreement**
+- Indefinite noun → indefinite adjective: كِتَابٌ كَبِيرٌ ✓
+- Definite noun → definite adjective: الْكِتَابُ الْكَبِيرُ ✓
+- Mismatch: الْكِتَابُ كَبِيرٌ ❌
+
+**Rule 3: Word Order**
+- Noun first, adjective second: كِتَابٌ كَبِيرٌ ✓
+- Adjective before noun: كَبِيرٌ كِتَابٌ ❌ (English order)
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Complete - Gender Agreement)
+**Question:** Complete the phrase with the correct form of "big":
+
+كِتَابٌ (kitaabun - book, masculine) + كَبِير/كَبِيرَة → ?
+
+**Correct Answer:** كِتَابٌ كَبِيرٌ
+
+**Explanation:** كِتَابٌ is masculine, so use the masculine adjective كَبِيرٌ (not كَبِيرَةٌ). Both are indefinite (with tanween).
+
+---
+
+### Question 2 (Complete - Gender + Definiteness)
+**Question:** Complete the phrase with the correct form of "big":
+
+الطَّاوِلَةُ (aT-Taawilatu - the table, feminine, definite) + كَبِير/كَبِيرَة → ?
+
+**Correct Answer:** الطَّاوِلَةُ الْكَبِيرَةُ
+
+**Explanation:** الطَّاوِلَةُ is feminine and definite, so use الْكَبِيرَةُ (feminine form with ال, no tanween). Both gender and definiteness must match.
+
+---
+
+### Question 3 (Identify Correct Phrase)
+**Question:** Which phrase has correct agreement?
+
+a) مَدْرَسَةٌ كَبِيرٌ (school, feminine + big, masculine)  
+b) مَدْرَسَةٌ كَبِيرَةٌ (school, feminine + big, feminine)  
+c) كَبِيرَةٌ مَدْرَسَةٌ (adjective before noun)
+
+**Correct Answer:** b) مَدْرَسَةٌ كَبِيرَةٌ
+
+**Explanation:** 
+- (a) has gender mismatch (feminine noun + masculine adjective)
+- (b) is correct (both feminine, both indefinite with tanween, correct order)
+- (c) has wrong word order (adjective before noun)
+
+---
+
+### Question 4 (Fix Agreement Error - Definiteness)
+**Question:** Fix the agreement error in this phrase:
+
+الْكِتَابُ كَبِيرٌ (al-kitaabu kabiir**un**)
+
+**Correct Answer:** الْكِتَابُ الْكَبِيرُ
+
+**Explanation:** الْكِتَابُ is definite (has ال), so the adjective must also be definite. Change كَبِيرٌ → الْكَبِيرُ (add ال, remove tanween).
+
+---
+
+### Question 5 (Fix Agreement Error - Gender)
+**Question:** Fix the agreement error in this phrase:
+
+بَيْتٌ جَمِيلَةٌ (baytun jamiilat**un**)
+
+**Correct Answer:** بَيْتٌ جَمِيلٌ
+
+**Explanation:** بَيْتٌ (house) is masculine, so use masculine adjective جَمِيلٌ (not feminine جَمِيلَةٌ). Remove the ة from the adjective.
+
+---
+
+### Question 6 (Fix Word Order)
+**Question:** Fix the word order in this phrase:
+
+كَبِيرٌ كِتَابٌ
+
+**Correct Answer:** كِتَابٌ كَبِيرٌ
+
+**Explanation:** In Arabic, the noun comes first, then the adjective. The phrase should be "book big" (كِتَابٌ كَبِيرٌ), not "big book" (English order).
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Adjective gender matches noun gender
+- Adjective definiteness matches noun definiteness (both have ال or both have tanween)
+- Word order is correct (noun before adjective)
+- All harakaat present
+
+**Partial Credit:**
+- Gender correct but definiteness wrong: 50%
+- Definiteness correct but gender wrong: 50%
+- Both correct but word order wrong: 80%
+- Missing harakaat only: 80%
+
+**Common Student Errors:**
+- Gender mismatch → Review: "Adjectives must match noun gender"
+- Definiteness mismatch → Review: "If noun has ال, adjective needs ال too"
+- English word order → Review: "Arabic is noun-adjective, not adjective-noun"
+- Both ال and tanween on adjective → Review: "ال and tanween are mutually exclusive"
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- Always show gender and definiteness in parentheses
+- One agreement rule per question (either gender OR definiteness)
+- Always provide transliteration
+- Use only lesson vocabulary
+
+**Intermediate (Lessons 2-3):**
+- Test both gender AND definiteness in same question
+- Sometimes omit hints (must identify noun gender from ة)
+- Mix vocabulary from multiple lessons
+- Include 2-adjective phrases: كِتَابٌ كَبِيرٌ جَدِيدٌ
+
+**Advanced (Lessons 4+):**
+- Test all three rules simultaneously (gender + definiteness + order)
+- No transliteration or hints
+- Include exception words (feminine without ة)
+- Sentence context: "I see ___" (must determine definiteness from context)
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand agreement rules
+2. **Pull vocabulary** from cached lesson content (nouns + adjectives)
+3. **Select noun and adjective**
+4. **Determine error type** (gender, definiteness, or word order)
+5. **Generate question** with appropriate format
+6. **Output JSON**:
+```json
+{
+  "question": "Complete the phrase with the correct form of 'big':",
+  "noun": {
+    "arabic": "كِتَابٌ",
+    "transliteration": "kitaabun",
+    "english": "book",
+    "gender": "masculine",
+    "definiteness": "indefinite"
+  },
+  "adjective": {
+    "english": "big",
+    "masculine_indefinite": "كَبِيرٌ",
+    "masculine_definite": "الْكَبِيرُ",
+    "feminine_indefinite": "كَبِيرَةٌ",
+    "feminine_definite": "الْكَبِيرَةُ"
+  },
+  "correct_answer": "كِتَابٌ كَبِيرٌ",
+  "explanation": "كِتَابٌ is masculine and indefinite, so use masculine indefinite adjective كَبِيرٌ"
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Noun and adjective genders are clear
+- [ ] Definiteness markers are correct (ال or tanween, never both)
+- [ ] Word order is Arabic (noun-adjective)
+- [ ] All vocabulary from current or previous lessons
+- [ ] Explanation clearly states which agreement rule(s) apply
+
+---
+
+## Reusability for Other Grammar Points
+
+This template is designed to be **reusable** for other agreement contexts:
+
+### Verb-Subject Agreement (Future Lessons)
+- Replace adjective with verb
+- Test gender/number agreement: هُوَ يَكْتُبُ (he writes) vs هِيَ تَكْتُبُ (she writes)
+
+### Pronoun Agreement
+- Replace adjective with pronoun
+- Test gender match: كِتَابٌ → هُوَ (book → it/he) vs طَاوِلَةٌ → هِيَ (table → it/she)
+
+### Demonstrative Agreement
+- هَذَا كِتَابٌ (this book, m) vs هَذِهِ طَاوِلَةٌ (this table, f)
+
+**To adapt this template:**
+1. Change `adjective_pool` to `verb_pool`, `pronoun_pool`, etc.
+2. Update agreement rules (e.g., verb prefixes instead of ة suffix)
+3. Keep same question types (complete, identify, fix)
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Tests two rules simultaneously (gender + definiteness)
+- Builds awareness that agreement is multi-dimensional
+- Common real-world pattern (noun-adjective phrases)
+- Foundation for more complex sentences
+
+**What this reveals:**
+- **Gender correct, definiteness wrong** → Understands gender but not definiteness rules
+- **Definiteness correct, gender wrong** → Doesn't recognize ة as feminine marker
+- **English word order** → Translating literally from English
+- **Both ال and tanween** → Doesn't understand they're mutually exclusive
+
+**Common patterns:**
+1. Students often get gender right first (ة is visual)
+2. Definiteness harder (requires understanding ال vs tanween)
+3. Word order mistakes persist (L1 interference from English)
+
+**Teaching sequence:**
+1. Gender agreement only (definite forms to avoid tanween complexity)
+2. Definiteness agreement only (same gender to isolate the rule)
+3. Both together (full agreement system)
+4. In sentences (realistic usage)
+
+---
+
+## Example Full Exercise Set (5 questions)
+
+```json
+[
+  {
+    "type": "complete",
+    "question": "كِتَابٌ + كَبِير/كَبِيرَة → ?",
+    "answer": "كِتَابٌ كَبِيرٌ"
+  },
+  {
+    "type": "identify",
+    "question": "Which is correct: (a) الطَّاوِلَةُ الْكَبِيرُ (b) الطَّاوِلَةُ الْكَبِيرَةُ (c) الطَّاوِلَةُ كَبِيرَةٌ",
+    "answer": "b"
+  },
+  {
+    "type": "fix",
+    "question": "Fix: مَدْرَسَةٌ جَدِيدٌ",
+    "answer": "مَدْرَسَةٌ جَدِيدَةٌ"
+  },
+  {
+    "type": "fix",
+    "question": "Fix: الْبَيْتُ قَدِيمٌ",
+    "answer": "الْبَيْتُ الْقَدِيمُ"
+  },
+  {
+    "type": "complete",
+    "question": "الْمَكْتَبُ + صَغِير/صَغِيرَة → ?",
+    "answer": "الْمَكْتَبُ الصَّغِيرُ"
+  }
+]
+```

--- a/data/rag_database/exercises/noun_adjective_agreement.md
+++ b/data/rag_database/exercises/noun_adjective_agreement.md
@@ -100,7 +100,7 @@ Fix the agreement error:
 ### Question 2 (Complete - Gender + Definiteness)
 **Question:** Complete the phrase with the correct form of "big":
 
-الطَّاوِلَةُ (aT-Taawilatu - the table, feminine, definite) + كَبِير/كَبِيرَة → ?
+الطَّاوِلَةُ (at-taawilatu - the table, feminine, definite) + كَبِير/كَبِيرَة → ?
 
 **Correct Answer:** الطَّاوِلَةُ الْكَبِيرَةُ
 

--- a/data/rag_database/exercises/paradigm_table_combined.md
+++ b/data/rag_database/exercises/paradigm_table_combined.md
@@ -1,0 +1,347 @@
+---
+exercise_type: paradigm_table
+grammar_point: full_noun_paradigm
+difficulty: beginner
+lesson_number: 1
+target_skill: systematic_form_generation
+reusable: true
+reusable_for: [noun_forms, verb_conjugation, pronoun_tables, adjective_declension, noun_cases]
+adaptation_params:
+  - table_headers: Column names for the paradigm
+  - row_categories: Row categories (e.g., person, number, gender)
+  - form_count: Number of forms in paradigm
+  - systematic_pattern: Pattern that connects forms
+---
+
+# Paradigm Table Exercise: Complete Noun Forms
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Generate all forms of a noun systematically
+2. Apply both gender and definiteness rules comprehensively
+3. See relationships between all forms of one word
+4. Build complete mental model of noun declension
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Complete this table for the word "{english}":
+
+| Gender | Indefinite | Definite |
+|--------|-----------|----------|
+| ?      | ?         | ?        |
+```
+
+**Answer Format:**
+```json
+{
+  "gender": "masculine" | "feminine",
+  "indefinite": "{arabic_indefinite}",
+  "definite": "{arabic_definite}"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with all forms
+- `question_count`: Number of tables to complete (default: 3-5)
+- `blanks_pattern`: "all" | "partial" | "mixed"
+- `difficulty`: beginner | intermediate | advanced
+
+### Blank Patterns
+
+**Pattern 1: All blanks (hardest)**
+```
+| Gender | Indefinite | Definite |
+|--------|-----------|----------|
+| ?      | ?         | ?        |
+```
+Given: "book" → Student fills all 3 cells
+
+**Pattern 2: Given one form (medium)**
+```
+| Gender | Indefinite     | Definite |
+|--------|----------------|----------|
+| ?      | كِتَابٌ        | ?        |
+```
+Given indefinite → Student identifies gender and produces definite
+
+**Pattern 3: Given gender only (easier)**
+```
+| Gender     | Indefinite | Definite |
+|------------|-----------|----------|
+| masculine  | ?         | ?        |
+```
+Given gender → Student produces both forms
+
+**Pattern 4: Mixed (one blank each)**
+```
+| Gender | Indefinite | Definite      |
+|--------|-----------|---------------|
+| ?      | طَاوِلَةٌ | ?             |
+
+| Gender     | Indefinite | Definite |
+|------------|-----------|----------|
+| masculine  | ?         | الْقَلَمُ |
+```
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (All Blanks)
+**Question:** Complete this table for the word "book":
+
+| Gender | Indefinite | Definite |
+|--------|-----------|----------|
+| ?      | ?         | ?        |
+
+**Correct Answer:**
+
+| Gender     | Indefinite | Definite    |
+|------------|-----------|-------------|
+| masculine  | كِتَابٌ    | الْكِتَابُ |
+
+**Explanation:**
+- Gender: masculine (no ة ending)
+- Indefinite: كِتَابٌ (kitaabun) - has tanween
+- Definite: الْكِتَابُ (al-kitaabu) - has ال, no tanween
+
+---
+
+### Question 2 (Given Indefinite)
+**Question:** Complete this table:
+
+| Gender | Indefinite     | Definite |
+|--------|----------------|----------|
+| ?      | مَدْرَسَةٌ      | ?        |
+
+**Correct Answer:**
+
+| Gender     | Indefinite     | Definite       |
+|------------|----------------|----------------|
+| feminine   | مَدْرَسَةٌ      | الْمَدْرَسَةُ   |
+
+**Explanation:**
+- Gender: feminine (ends in ة)
+- Indefinite: مَدْرَسَةٌ (given) - has ة and tanween
+- Definite: الْمَدْرَسَةُ (al-madrasatu) - add ال, remove tanween
+
+---
+
+### Question 3 (Given Definite)
+**Question:** Complete this table:
+
+| Gender | Indefinite | Definite      |
+|--------|-----------|---------------|
+| ?      | ?         | الطَّاوِلَةُ   |
+
+**Correct Answer:**
+
+| Gender     | Indefinite   | Definite      |
+|------------|-------------|---------------|
+| feminine   | طَاوِلَةٌ    | الطَّاوِلَةُ   |
+
+**Explanation:**
+- Gender: feminine (has ة in definite form)
+- Indefinite: طَاوِلَةٌ (taawilatun) - remove ال, add tanween
+- Definite: الطَّاوِلَةُ (given) - has ال, no tanween
+
+---
+
+### Question 4 (Given Gender - Masculine)
+**Question:** Complete this table for "pen":
+
+| Gender     | Indefinite | Definite |
+|------------|-----------|----------|
+| masculine  | ?         | ?        |
+
+**Correct Answer:**
+
+| Gender     | Indefinite | Definite   |
+|------------|-----------|------------|
+| masculine  | قَلَمٌ     | الْقَلَمُ  |
+
+**Explanation:**
+- Gender: masculine (given) - no ة ending
+- Indefinite: قَلَمٌ (qalamun) - has tanween
+- Definite: الْقَلَمُ (al-qalamu) - has ال, no tanween
+
+---
+
+### Question 5 (Multiple Tables - Challenge)
+**Question:** Complete both tables:
+
+**Table A: "door"**
+| Gender | Indefinite | Definite |
+|--------|-----------|----------|
+| ?      | ?         | ?        |
+
+**Table B: "window"**
+| Gender | Indefinite | Definite |
+|--------|-----------|----------|
+| ?      | ?         | ?        |
+
+**Correct Answer:**
+
+**Table A:**
+| Gender     | Indefinite | Definite  |
+|------------|-----------|-----------|
+| masculine  | بَابٌ      | الْبَابُ  |
+
+**Table B:**
+| Gender     | Indefinite  | Definite      |
+|------------|-------------|---------------|
+| feminine   | نَافِذَةٌ   | النَّافِذَةُ  |
+
+**Explanation:**
+- Door (بَابٌ): masculine (no ة), indefinite بَابٌ, definite الْبَابُ
+- Window (نَافِذَةٌ): feminine (has ة), indefinite نَافِذَةٌ, definite النَّافِذَةُ
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Gender identification is correct
+- Indefinite form has tanween (ٌ), no ال
+- Definite form has ال, no tanween
+- All harakaat present
+- Feminine forms have ة, masculine forms do not
+
+**Partial Credit per cell:**
+- Gender: 20% of total
+- Indefinite: 40% of total
+- Definite: 40% of total
+
+**Common Errors:**
+- Gender wrong but forms consistent → 50% (applied rules correctly to wrong gender)
+- Indefinite has ال or missing tanween → 0% for that cell
+- Definite missing ال or has tanween → 0% for that cell
+- Missing harakaat → 80% for that cell
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- One table per question
+- Given 1-2 cells (only fill 1-2 blanks)
+- Always provide English word as hint
+- Use only lesson vocabulary
+
+**Intermediate (Lessons 2-3):**
+- One table per question
+- Given 0-1 cells (fill 2-3 blanks)
+- Sometimes no English hint (work from given Arabic form)
+- Mix vocabulary from multiple lessons
+
+**Advanced (Lessons 4+):**
+- Multiple tables per question (2-3 words)
+- All blanks (fill entire table)
+- No English hints
+- Include exception words
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand table structure
+2. **Pull vocabulary** from cached lesson content
+3. **Select blank pattern** based on difficulty
+4. **Generate table** with appropriate blanks
+5. **Output JSON**:
+```json
+{
+  "question": "Complete this table for the word 'book':",
+  "english_word": "book",
+  "table": {
+    "given_cells": {
+      "gender": null,
+      "indefinite": null,
+      "definite": null
+    },
+    "correct_answers": {
+      "gender": "masculine",
+      "indefinite": "كِتَابٌ",
+      "definite": "الْكِتَابُ"
+    }
+  },
+  "explanation": "masculine (no ة), indefinite كِتَابٌ (has tanween), definite الْكِتَابُ (has ال, no tanween)"
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Indefinite forms have tanween (ٌ)
+- [ ] Definite forms have ال prefix (no tanween)
+- [ ] Gender matches ة presence
+- [ ] All vocabulary from current or previous lessons
+- [ ] Blank pattern appropriate for difficulty level
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Shows systematic relationships (not isolated forms)
+- Builds paradigm thinking (all forms of one word)
+- Reinforces mutual exclusivity of ال and tanween
+- Visual format aids memory
+
+**What this reveals:**
+- **Can't identify gender from forms** → Doesn't recognize ة pattern
+- **Produces both forms but wrong gender** → Understands mechanics but not gender identification
+- **Confuses which form is indefinite/definite** → Doesn't understand marker meanings
+- **Mixes ال and tanween** → Fundamental misunderstanding of definiteness
+
+**Learning progression:**
+1. **Given 2 cells** → Fill 1 (easiest)
+2. **Given 1 cell** → Fill 2 (medium)
+3. **Given 0 cells** → Fill 3 (hardest)
+4. **Multiple tables** → Systematic practice
+
+**Comparison to linguistic paradigms:**
+```
+Traditional noun paradigm:
+        Singular  | Plural
+Nom.    كِتَابٌ   | كُتُبٌ
+Acc.    كِتَابًا  | كُتُبًا
+Gen.    كِتَابٍ   | كُتُبٍ
+
+Our beginner paradigm:
+         Indefinite | Definite
+Gender   masculine  |
+Form     كِتَابٌ     | الْكِتَابُ
+```
+
+We simplify to essential contrasts for beginners.
+
+---
+
+## UI/Implementation Notes
+
+**For web interface:**
+- Interactive table with editable cells
+- Color-code given cells (gray) vs. blank cells (white)
+- Show checkmark/X per cell as student fills
+- Allow submit after all blanks filled
+
+**For text interface:**
+- Label cells: "Gender:", "Indefinite:", "Definite:"
+- Student responds: "Gender: masculine, Indefinite: كِتَابٌ, Definite: الْكِتَابُ"
+- Accept abbreviated format: "m, كِتَابٌ, الْكِتَابُ"
+
+**Accessibility:**
+- Screen reader support for table navigation
+- Keyboard shortcuts to move between cells
+- Option to see table as list format

--- a/data/rag_database/exercises/pattern_recognition_gender.md
+++ b/data/rag_database/exercises/pattern_recognition_gender.md
@@ -1,0 +1,219 @@
+---
+exercise_type: pattern_recognition
+grammar_point: gender_identification
+difficulty: beginner
+lesson_number: 1
+target_skill: quick_gender_pattern_spotting
+---
+
+# Pattern Recognition Exercise: Gender Identification
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Quickly identify feminine nouns among mixed lists
+2. Recognize the ة (taa marbuuta) pattern at a glance
+3. Build visual recognition speed for gender markers
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Circle/Select all the feminine nouns:
+
+{word_list}
+```
+
+**Answer Format:**
+```json
+{
+  "correct_selections": ["word1", "word2", ...],
+  "explanation": "Brief explanation"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with Arabic, transliteration, English, gender
+- `total_words`: Number of words to show (default: 6-8)
+- `feminine_count`: Number of feminine nouns (default: 2-4)
+- `difficulty`: beginner | intermediate | advanced
+
+### Question Generation Logic
+
+**For each question:**
+1. Select {feminine_count} feminine nouns from vocabulary_pool
+2. Select remaining words as masculine nouns
+3. Present all words in random order
+4. Student selects only the feminine nouns
+
+**Variation patterns:**
+- Beginner: 6 words, 3 feminine (50%)
+- Intermediate: 8 words, 3 feminine (37.5%)
+- Advanced: 10 words, 2-3 feminine (20-30%, harder to spot)
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Beginner)
+**Question:** Select all the feminine nouns from this list:
+
+- كِتَابٌ (kitaabun) - book
+- مَدْرَسَةٌ (madrasatun) - school
+- قَلَمٌ (qalamun) - pen
+- طَاوِلَةٌ (taawilatun) - table
+- بَابٌ (baabun) - door
+- غُرْفَةٌ (ghurfatun) - room
+
+**Correct Answer:**
+```json
+{
+  "correct_selections": ["مَدْرَسَةٌ", "طَاوِلَةٌ", "غُرْفَةٌ"],
+  "explanation": "Look for ة (taa marbuuta) at the end. Three words have it: مَدْرَسَةٌ (school), طَاوِلَةٌ (table), غُرْفَةٌ (room)."
+}
+```
+
+---
+
+### Question 2 (Intermediate - no transliteration)
+**Question:** Select all the feminine nouns:
+
+- بَيْتٌ (house)
+- كُرْسِيٌّ (chair)
+- نَافِذَةٌ (window)
+- مَكْتَبٌ (office)
+- مَدْرَسَةٌ (school)
+- كِتَابٌ (book)
+- بَابٌ (door)
+- طَاوِلَةٌ (table)
+
+**Correct Answer:**
+```json
+{
+  "correct_selections": ["نَافِذَةٌ", "مَدْرَسَةٌ", "طَاوِلَةٌ"],
+  "explanation": "Three words end in ة: نَافِذَةٌ, مَدْرَسَةٌ, طَاوِلَةٌ. These are all feminine."
+}
+```
+
+---
+
+### Question 3 (Challenge - mostly masculine)
+**Question:** Select all the feminine nouns:
+
+- كِتَابٌ (book)
+- قَلَمٌ (pen)
+- بَيْتٌ (house)
+- طَاوِلَةٌ (table)
+- بَابٌ (door)
+- مَكْتَبٌ (office)
+- كُرْسِيٌّ (chair)
+
+**Correct Answer:**
+```json
+{
+  "correct_selections": ["طَاوِلَةٌ"],
+  "explanation": "Only one word ends in ة: طَاوِلَةٌ (table). The rest are masculine."
+}
+```
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Student selects ALL feminine nouns
+- Student selects ONLY feminine nouns (no false positives)
+- Both precision and recall must be 100%
+
+**Partial Credit:**
+- If student misses 1 feminine noun: 80% credit
+- If student incorrectly selects 1 masculine noun: 80% credit
+- Calculate: (correct selections / total selections) × (correct selections / total feminine)
+
+**Common Errors:**
+- Missing some feminine nouns (recall issue) → "Did you check all words for ة?"
+- Selecting masculine nouns (precision issue) → "Remember, only words ending in ة are feminine"
+- Not selecting any / selecting all → Review basic ة rule
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- 6 words total
+- 3 feminine (50% - easy to spot)
+- Always show transliteration and English
+- Use only lesson vocabulary
+
+**Intermediate (Lessons 2-3):**
+- 8 words total
+- 2-3 feminine (25-37.5% - requires careful checking)
+- Show English meaning, no transliteration
+- Mix vocabulary from multiple lessons
+
+**Advanced (Lessons 4+):**
+- 10-12 words total
+- 2-3 feminine (16-25% - needle in haystack)
+- Arabic only, no translations
+- Include exception words (if taught)
+- Time pressure (speed challenge)
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand structure
+2. **Pull vocabulary** from cached lesson content
+3. **Select feminine and masculine nouns**
+4. **Randomize order** (don't cluster feminine together)
+5. **Output JSON**:
+```json
+{
+  "question": "Select all the feminine nouns from this list:",
+  "words": [
+    {"arabic": "كِتَابٌ", "transliteration": "kitaabun", "english": "book", "gender": "masculine"},
+    {"arabic": "مَدْرَسَةٌ", "transliteration": "madrasatun", "english": "school", "gender": "feminine"},
+    {"arabic": "قَلَمٌ", "transliteration": "qalamun", "english": "pen", "gender": "masculine"},
+    {"arabic": "طَاوِلَةٌ", "transliteration": "taawilatun", "english": "table", "gender": "feminine"},
+    {"arabic": "بَابٌ", "transliteration": "baabun", "english": "door", "gender": "masculine"},
+    {"arabic": "غُرْفَةٌ", "transliteration": "ghurfatun", "english": "room", "gender": "feminine"}
+  ],
+  "correct_selections": ["مَدْرَسَةٌ", "طَاوِلَةٌ", "غُرْفَةٌ"],
+  "explanation": "Look for ة at the end. Three words have it: مَدْرَسَةٌ, طَاوِلَةٌ, غُرْفَةٌ."
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Feminine nouns scattered throughout list (not grouped)
+- [ ] Mix of masculine and feminine appropriate for difficulty level
+- [ ] All vocabulary from current or previous lessons
+- [ ] Explanation clearly identifies the ة pattern
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Builds pattern recognition speed
+- Requires active searching (not passive multiple choice)
+- Simulates real reading scenarios (scanning text for specific patterns)
+- Can be gamified with speed challenges
+
+**Learning progression:**
+1. **First exposure**: 50% feminine (easy pattern recognition)
+2. **Building skill**: 37% feminine (more careful checking)
+3. **Mastery**: 20-25% feminine (rapid scanning of longer lists)
+
+**Speed targets (optional):**
+- Beginner: No time limit
+- Intermediate: 30 seconds for 8 words
+- Advanced: 45 seconds for 12 words

--- a/data/rag_database/exercises/sentence_level_combined.md
+++ b/data/rag_database/exercises/sentence_level_combined.md
@@ -33,7 +33,7 @@ Translation: {english_translation}
 ```json
 {
   "corrected_sentence": "{sentence_in_arabic}",
-  "errors_found": [
+  "corrections": [
     {"word": "...", "error_type": "...", "fix": "..."}
   ],
   "explanation": "Brief explanation"
@@ -86,10 +86,10 @@ The big كِتَابٌ is on the table.
 ```json
 {
   "corrected_sentence": "The big الْكِتَابُ is on the table.",
-  "errors_found": [
+  "corrections": [
     {
-      "original_word": "كِتَابٌ",
-      "corrected_word": "الْكِتَابُ",
+      "original": "كِتَابٌ",
+      "corrected": "الْكِتَابُ",
       "error_type": "wrong_definiteness",
       "explanation": "'The book' is definite, needs ال and no tanween"
     }
@@ -110,16 +110,16 @@ I see a كِتَاب on الطَّاوِلَةٌ.
 ```json
 {
   "corrected_sentence": "I see a كِتَابٌ on الطَّاوِلَةُ.",
-  "errors_found": [
+  "corrections": [
     {
-      "original_word": "كِتَاب",
-      "corrected_word": "كِتَابٌ",
+      "original": "كِتَاب",
+      "corrected": "كِتَابٌ",
       "error_type": "missing_tanween",
       "explanation": "'A book' is indefinite, needs tanween"
     },
     {
-      "original_word": "الطَّاوِلَةٌ",
-      "corrected_word": "الطَّاوِلَةُ",
+      "original": "الطَّاوِلَةٌ",
+      "corrected": "الطَّاوِلَةُ",
       "error_type": "al_tanween_conflict",
       "explanation": "Definite word cannot have tanween, remove it"
     }
@@ -140,16 +140,16 @@ There is a مَدْرَسَةُ near the بَيْتٌ.
 ```json
 {
   "corrected_sentence": "There is a مَدْرَسَةٌ near the الْبَيْتُ.",
-  "errors_found": [
+  "corrections": [
     {
-      "original_word": "مَدْرَسَةُ",
-      "corrected_word": "مَدْرَسَةٌ",
+      "original": "مَدْرَسَةُ",
+      "corrected": "مَدْرَسَةٌ",
       "error_type": "missing_tanween",
       "explanation": "'A school' is indefinite (uses 'a'), needs tanween not just damma"
     },
     {
-      "original_word": "بَيْتٌ",
-      "corrected_word": "الْبَيْتُ",
+      "original": "بَيْتٌ",
+      "corrected": "الْبَيْتُ",
       "error_type": "missing_al",
       "explanation": "'The house' is definite (uses 'the'), needs ال and no tanween"
     }
@@ -172,16 +172,16 @@ There is a مَدْرَسَةُ near the بَيْتٌ.
 ```json
 {
   "corrected_sentence": "الْكِتَابُ فِي غُرْفَةٌ",
-  "errors_found": [
+  "corrections": [
     {
-      "original_word": "الْكِتَابٌ",
-      "corrected_word": "الْكِتَابُ",
+      "original": "الْكِتَابٌ",
+      "corrected": "الْكِتَابُ",
       "error_type": "al_tanween_conflict",
       "explanation": "Remove tanween from definite noun"
     },
     {
-      "original_word": "غُرْفَة",
-      "corrected_word": "غُرْفَةٌ",
+      "original": "غُرْفَة",
+      "corrected": "غُرْفَةٌ",
       "error_type": "missing_tanween",
       "explanation": "Indefinite noun (a room) needs tanween"
     }
@@ -202,22 +202,22 @@ I see الْقَلَمٌ and كِتَاب and a طَاوِلَةُ.
 ```json
 {
   "corrected_sentence": "I see الْقَلَمُ and كِتَابٌ and a طَاوِلَةٌ.",
-  "errors_found": [
+  "corrections": [
     {
-      "original_word": "الْقَلَمٌ",
-      "corrected_word": "الْقَلَمُ",
+      "original": "الْقَلَمٌ",
+      "corrected": "الْقَلَمُ",
       "error_type": "al_tanween_conflict",
       "explanation": "'The pen' has ال, remove tanween"
     },
     {
-      "original_word": "كِتَاب",
-      "corrected_word": "كِتَابٌ",
+      "original": "كِتَاب",
+      "corrected": "كِتَابٌ",
       "error_type": "missing_tanween",
       "explanation": "Indefinite 'a book' needs tanween"
     },
     {
-      "original_word": "طَاوِلَةُ",
-      "corrected_word": "طَاوِلَةٌ",
+      "original": "طَاوِلَةُ",
+      "corrected": "طَاوِلَةٌ",
       "error_type": "wrong_vowel",
       "explanation": "'A table' is indefinite, needs tanween not just damma"
     }
@@ -290,8 +290,8 @@ I see الْقَلَمٌ and كِتَاب and a طَاوِلَةُ.
   "errors": [
     {
       "position": 2,
-      "original_word": "كِتَابٌ",
-      "corrected_word": "الْكِتَابُ",
+      "original": "كِتَابٌ",
+      "corrected": "الْكِتَابُ",
       "error_type": "wrong_definiteness",
       "explanation": "'The book' is definite, needs ال"
     }

--- a/data/rag_database/exercises/sentence_level_combined.md
+++ b/data/rag_database/exercises/sentence_level_combined.md
@@ -1,0 +1,372 @@
+---
+exercise_type: sentence_level
+grammar_point: contextual_application
+difficulty: intermediate
+lesson_number: 1
+target_skill: applying_rules_in_sentence_context
+---
+
+# Sentence-Level Exercise: Contextual Application
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Apply gender and definiteness rules in sentence context
+2. Fix errors in multi-word sentences
+3. Recognize when context requires definite or indefinite forms
+4. Integrate grammar rules with real language use
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Fix the errors in this sentence:
+
+{sentence_with_errors}
+
+Translation: {english_translation}
+```
+
+**Answer Format:**
+```json
+{
+  "corrected_sentence": "{sentence_in_arabic}",
+  "errors_found": [
+    {"word": "...", "error_type": "...", "fix": "..."}
+  ],
+  "explanation": "Brief explanation"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with all forms
+- `sentence_complexity`: "simple" | "compound"
+- `error_count`: Number of errors per sentence (1-3)
+- `difficulty`: intermediate | advanced
+
+### Error Types in Context
+
+**Type 1: Wrong definiteness for context**
+```
+Error: "I have كِتَابُ" (missing marker)
+Correct: "I have كِتَابٌ" (indefinite - "a book")
+Context clue: "a" in English = indefinite
+```
+
+**Type 2: Gender mismatch**
+```
+Error: "The big مَدْرَسَةٌ" (wrong form)
+Correct: "The big مَدْرَسَةُ" or "The big الْمَدْرَسَةُ" 
+Context clue: "the" requires definite form
+```
+
+**Type 3: Multiple errors in one sentence**
+```
+Error: "الْكِتَابٌ is on طَاوِلَة"
+Correct: "الْكِتَابُ is on طَاوِلَةٌ"
+Two errors: ال + tanween conflict, missing tanween
+```
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Simple - One Error)
+**Question:** Fix the error in this sentence:
+
+The big كِتَابٌ is on the table.
+
+**Correct Answer:**
+```json
+{
+  "corrected_sentence": "The big الْكِتَابُ is on the table.",
+  "errors_found": [
+    {
+      "original_word": "كِتَابٌ",
+      "corrected_word": "الْكِتَابُ",
+      "error_type": "wrong_definiteness",
+      "explanation": "'The book' is definite, needs ال and no tanween"
+    }
+  ]
+}
+```
+
+**Explanation:** English "the" signals definite article needed. Change كِتَابٌ → الْكِتَابُ
+
+---
+
+### Question 2 (Two Words, One Error Each)
+**Question:** Fix the errors in this sentence:
+
+I see a كِتَاب on الطَّاوِلَةٌ.
+
+**Correct Answer:**
+```json
+{
+  "corrected_sentence": "I see a كِتَابٌ on الطَّاوِلَةُ.",
+  "errors_found": [
+    {
+      "original_word": "كِتَاب",
+      "corrected_word": "كِتَابٌ",
+      "error_type": "missing_tanween",
+      "explanation": "'A book' is indefinite, needs tanween"
+    },
+    {
+      "original_word": "الطَّاوِلَةٌ",
+      "corrected_word": "الطَّاوِلَةُ",
+      "error_type": "al_tanween_conflict",
+      "explanation": "Definite word cannot have tanween, remove it"
+    }
+  ]
+}
+```
+
+**Explanation:** "A" requires tanween (كِتَابٌ). "The" (ال) cannot have tanween (الطَّاوِلَةُ).
+
+---
+
+### Question 3 (Context Clues)
+**Question:** Fix the errors based on context:
+
+There is a مَدْرَسَةُ near the بَيْتٌ.
+
+**Correct Answer:**
+```json
+{
+  "corrected_sentence": "There is a مَدْرَسَةٌ near the الْبَيْتُ.",
+  "errors_found": [
+    {
+      "original_word": "مَدْرَسَةُ",
+      "corrected_word": "مَدْرَسَةٌ",
+      "error_type": "missing_tanween",
+      "explanation": "'A school' is indefinite (uses 'a'), needs tanween not just damma"
+    },
+    {
+      "original_word": "بَيْتٌ",
+      "corrected_word": "الْبَيْتُ",
+      "error_type": "missing_al",
+      "explanation": "'The house' is definite (uses 'the'), needs ال and no tanween"
+    }
+  ]
+}
+```
+
+**Explanation:** Context words "a" and "the" signal which form to use. "A" = tanween, "the" = ال.
+
+---
+
+### Question 4 (All Arabic Sentence)
+**Question:** Fix the errors in this Arabic sentence:
+
+**Arabic:** الْكِتَابٌ فِي غُرْفَة
+
+**Translation:** The book is in a room.
+
+**Correct Answer:**
+```json
+{
+  "corrected_sentence": "الْكِتَابُ فِي غُرْفَةٌ",
+  "errors_found": [
+    {
+      "original_word": "الْكِتَابٌ",
+      "corrected_word": "الْكِتَابُ",
+      "error_type": "al_tanween_conflict",
+      "explanation": "Remove tanween from definite noun"
+    },
+    {
+      "original_word": "غُرْفَة",
+      "corrected_word": "غُرْفَةٌ",
+      "error_type": "missing_tanween",
+      "explanation": "Indefinite noun (a room) needs tanween"
+    }
+  ]
+}
+```
+
+**Explanation:** الْكِتَابُ is definite (the book), غُرْفَةٌ is indefinite (a room).
+
+---
+
+### Question 5 (Longer Sentence - Advanced)
+**Question:** Fix all errors:
+
+I see الْقَلَمٌ and كِتَاب and a طَاوِلَةُ.
+
+**Correct Answer:**
+```json
+{
+  "corrected_sentence": "I see الْقَلَمُ and كِتَابٌ and a طَاوِلَةٌ.",
+  "errors_found": [
+    {
+      "original_word": "الْقَلَمٌ",
+      "corrected_word": "الْقَلَمُ",
+      "error_type": "al_tanween_conflict",
+      "explanation": "'The pen' has ال, remove tanween"
+    },
+    {
+      "original_word": "كِتَاب",
+      "corrected_word": "كِتَابٌ",
+      "error_type": "missing_tanween",
+      "explanation": "Indefinite 'a book' needs tanween"
+    },
+    {
+      "original_word": "طَاوِلَةُ",
+      "corrected_word": "طَاوِلَةٌ",
+      "error_type": "wrong_vowel",
+      "explanation": "'A table' is indefinite, needs tanween not just damma"
+    }
+  ]
+}
+```
+
+**Explanation:** Three errors: ال+tanween conflict, missing tanween, wrong indefinite marking.
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- All errors identified
+- All corrections are accurate
+- Final sentence is grammatically correct
+- No unnecessary changes to correct words
+
+**Partial Credit:**
+- Identify all errors but fix some incorrectly: 70%
+- Miss one error but fix others correctly: 60-80% (depending on sentence length)
+- Over-correct (change correct words): -10% per false positive
+
+**Common Student Errors:**
+- Fix obvious errors but miss subtle ones → Need more practice identifying all error types
+- Change correct words → Overapplying rules, needs confidence building
+- Correct one word type but not others → Focused on one rule, forgetting others
+
+---
+
+## Adaptive Difficulty
+
+**Intermediate (Lesson 1):**
+- 2-3 word sentences
+- 1-2 errors per sentence
+- Mix Arabic and English words
+- Provide English translation
+
+**Advanced (Lessons 2+):**
+- 4-6 word sentences
+- 2-3 errors per sentence
+- All Arabic sentences
+- English translation provided but test without it
+
+**Expert:**
+- Full paragraph (3-4 sentences)
+- 4-6 errors across paragraph
+- Arabic only
+- No translation (infer from context)
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand sentence patterns
+2. **Pull vocabulary** from cached lesson content
+3. **Construct sentence** with meaningful context
+4. **Introduce errors** (1-3 per sentence)
+5. **Ensure errors are fixable** (not ambiguous)
+6. **Output JSON**:
+```json
+{
+  "question": "Fix the errors in this sentence:",
+  "sentence_with_errors": "The big كِتَابٌ is on the table.",
+  "translation": "The big book is on the table.",
+  "correct_sentence": "The big الْكِتَابُ is on the table.",
+  "errors": [
+    {
+      "position": 2,
+      "original_word": "كِتَابٌ",
+      "corrected_word": "الْكِتَابُ",
+      "error_type": "wrong_definiteness",
+      "explanation": "'The book' is definite, needs ال"
+    }
+  ]
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat
+- [ ] Context clearly indicates correct form (definite/indefinite)
+- [ ] Errors are realistic (common student mistakes)
+- [ ] Not too many errors (overwhelming)
+- [ ] Translation helps student understand context
+- [ ] All vocabulary from current or previous lessons
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Tests application in context (not isolated rules)
+- Builds reading skills (identifying errors while reading)
+- Mimics real editing tasks
+- Shows importance of context for definiteness
+
+**What this reveals:**
+- **Fixes ال errors but not tanween** → Prioritizing one rule over others
+- **Doesn't use English context clues** → Not connecting translation to grammar
+- **Changes correct words** → Lacks confidence, over-applies rules
+- **Only fixes first error** → Not reading carefully enough
+
+**Learning progression:**
+1. **Mixed language sentences** (English + Arabic) - context obvious
+2. **All Arabic with translation** - must connect translation to form
+3. **All Arabic, no translation** - infer from sentence context
+4. **Paragraph-level** - sustained attention, multiple sentences
+
+**Real-world connection:**
+- This mimics how students will use Arabic in writing
+- Errors in context are harder to spot than isolated words
+- Builds proofreading skills (checking own writing)
+- Develops sensitivity to definiteness in natural language
+
+**Common contexts to test:**
+
+**Definite contexts (require ال):**
+- "The X" (explicit article)
+- "Look at X" (definite in context)
+- "X is beautiful" (previously mentioned)
+
+**Indefinite contexts (require tanween):**
+- "A X" (explicit article)
+- "I have X" (new information)
+- "There is X" (introducing entity)
+
+---
+
+## Variations
+
+**Error Type Focus:**
+- Give all sentences with same error type (e.g., all ال + tanween conflicts)
+- Builds pattern recognition for specific mistakes
+
+**Progressive Reveal:**
+- Show sentence word by word
+- Student marks error as they see it
+- Tests real-time reading comprehension
+
+**Collaborative Editing:**
+- Pair students
+- Student A writes sentence, Student B finds errors
+- Peer learning + writing practice
+
+**Dictation + Correction:**
+- Teacher says sentence with error
+- Student writes what they hear
+- Then identifies and corrects the error
+- Tests listening, spelling, and error detection

--- a/data/rag_database/exercises/sorting_gender_categorization.md
+++ b/data/rag_database/exercises/sorting_gender_categorization.md
@@ -1,0 +1,209 @@
+---
+exercise_type: sorting
+grammar_point: gender_categorization
+difficulty: beginner
+lesson_number: 1
+target_skill: categorizing_nouns_by_gender
+reusable: true
+reusable_for: [gender, verb_tense, noun_number, adjective_type, sentence_type, pronoun_person]
+adaptation_params:
+  - category_names: Names of categories to sort into
+  - category_count: Number of categories (2-3)
+  - identification_rule: How to determine category membership
+---
+
+# Sorting Exercise: Gender Categorization
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Identify multiple nouns as masculine or feminine
+2. Recognize the ة (taa marbuuta) pattern across multiple words
+3. Sort and categorize vocabulary by gender
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Sort these {count} words into masculine and feminine columns:
+
+Words: {words_list}
+
+Masculine: [drag/type here]
+Feminine: [drag/type here]
+```
+
+**Answer Format:**
+```json
+{
+  "masculine": ["word1", "word2", ...],
+  "feminine": ["word3", "word4", ...]
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with Arabic, transliteration, English, gender
+- `word_count`: Number of words to sort (default: 6)
+- `difficulty`: beginner | intermediate | advanced
+
+### Question Generation Logic
+
+**For each question:**
+1. Select {word_count} nouns from vocabulary_pool
+2. Aim for ~50/50 masculine/feminine split
+3. Present words in random order (mixed gender)
+4. Student must sort into two categories
+
+**Variation patterns:**
+- Beginner: Show transliteration with Arabic
+- Intermediate: Arabic only, no transliteration
+- Advanced: Mix in exception words (if taught)
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Beginner - 6 words)
+**Question:** Sort these 6 words into masculine and feminine columns:
+
+**Words:**
+- كِتَابٌ (kitaabun) - book
+- مَدْرَسَةٌ (madrasatun) - school
+- قَلَمٌ (qalamun) - pen
+- طَاوِلَةٌ (taawilatun) - table
+- بَابٌ (baabun) - door
+- غُرْفَةٌ (ghurfatun) - room
+
+**Correct Answer:**
+```json
+{
+  "masculine": ["كِتَابٌ", "قَلَمٌ", "بَابٌ"],
+  "feminine": ["مَدْرَسَةٌ", "طَاوِلَةٌ", "غُرْفَةٌ"]
+}
+```
+
+**Explanation:** Feminine nouns end in ة (taa marbuuta): مَدْرَسَةٌ, طَاوِلَةٌ, غُرْفَةٌ. Masculine nouns do not have this ending: كِتَابٌ, قَلَمٌ, بَابٌ.
+
+---
+
+### Question 2 (Intermediate - 8 words, no transliteration)
+**Question:** Sort these 8 words into masculine and feminine columns:
+
+**Words:**
+- بَيْتٌ (house)
+- نَافِذَةٌ (window)
+- مَكْتَبٌ (office)
+- كُرْسِيٌّ (chair)
+- مَدْرَسَةٌ (school)
+- كِتَابٌ (book)
+- طَاوِلَةٌ (table)
+- قَلَمٌ (pen)
+
+**Correct Answer:**
+```json
+{
+  "masculine": ["بَيْتٌ", "مَكْتَبٌ", "كُرْسِيٌّ", "كِتَابٌ", "قَلَمٌ"],
+  "feminine": ["نَافِذَةٌ", "مَدْرَسَةٌ", "طَاوِلَةٌ"]
+}
+```
+
+**Explanation:** Look for ة at the end of words. Three words have ة (feminine), five do not (masculine).
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- All masculine nouns are in masculine category
+- All feminine nouns are in feminine category
+- No words are missing or duplicated
+- Accept either Arabic or English word as identifier
+
+**Partial Credit:**
+- If 75%+ correct, give partial credit with feedback on mistakes
+- Identify specific words that were miscategorized
+
+**Common Errors:**
+- Student puts all words in one category → Review gender rules
+- Student confuses specific words → Practice those words individually
+- Student categorizes by meaning rather than grammar → Re-explain ة rule
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- 6 words total
+- Always show transliteration and English
+- Clear 50/50 split (3 masculine, 3 feminine)
+- Use only lesson vocabulary
+
+**Intermediate (Lessons 2-3):**
+- 8 words total
+- Show English meaning, no transliteration
+- Uneven split (e.g., 5 masculine, 3 feminine)
+- Mix vocabulary from multiple lessons
+
+**Advanced (Lessons 4+):**
+- 10 words total
+- Arabic only, no translations
+- Include exception words (feminine without ة)
+- Time limit challenge
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand structure
+2. **Pull vocabulary** from cached lesson content
+3. **Generate question** with mixed gender words
+4. **Randomize order** so masculine/feminine aren't grouped
+5. **Output JSON**:
+```json
+{
+  "question": "Sort these 6 words into masculine and feminine columns:",
+  "words": [
+    {"arabic": "كِتَابٌ", "transliteration": "kitaabun", "english": "book"},
+    {"arabic": "مَدْرَسَةٌ", "transliteration": "madrasatun", "english": "school"},
+    {"arabic": "قَلَمٌ", "transliteration": "qalamun", "english": "pen"},
+    {"arabic": "طَاوِلَةٌ", "transliteration": "taawilatun", "english": "table"},
+    {"arabic": "بَابٌ", "transliteration": "baabun", "english": "door"},
+    {"arabic": "غُرْفَةٌ", "transliteration": "ghurfatun", "english": "room"}
+  ],
+  "correct_answer": {
+    "masculine": ["كِتَابٌ", "قَلَمٌ", "بَابٌ"],
+    "feminine": ["مَدْرَسَةٌ", "طَاوِلَةٌ", "غُرْفَةٌ"]
+  },
+  "explanation": "Feminine nouns end in ة: مَدْرَسَةٌ, طَاوِلَةٌ, غُرْفَةٌ. Masculine nouns do not: كِتَابٌ, قَلَمٌ, بَابٌ."
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Words are presented in random order (not pre-sorted)
+- [ ] Approximately balanced masculine/feminine split
+- [ ] All vocabulary from current or previous lessons
+- [ ] Explanation references the ة rule
+
+---
+
+## UI/Implementation Notes
+
+**For web interface:**
+- Drag-and-drop interface works well for this exercise
+- Two drop zones: "Masculine" and "Feminine"
+- Show checkmark/X after each word is sorted
+- Allow re-sorting before final submission
+
+**For text interface:**
+- Student can list words: "Masculine: كِتَابٌ, قَلَمٌ, بَابٌ"
+- Accept comma-separated lists
+- Accept English or Arabic as identifiers

--- a/data/rag_database/exercises/transformation_chain_definite_article.md
+++ b/data/rag_database/exercises/transformation_chain_definite_article.md
@@ -1,0 +1,273 @@
+---
+exercise_type: transformation_chain
+grammar_point: definite_article_transformation
+difficulty: beginner
+lesson_number: 1
+target_skill: bidirectional_al_transformation
+reusable: true
+reusable_for: [definite_article, verb_conjugation, singular_plural, present_past, adjective_forms]
+adaptation_params:
+  - transformation_rule: Description of A → B transformation
+  - forward_transformation: How to transform A to B
+  - backward_transformation: How to transform B back to A
+  - cycle_pattern: Pattern for full cycle (A → B → A)
+---
+
+# Transformation Chain Exercise: Definite Article
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Transform indefinite → definite (add ال, remove tanween)
+2. Transform definite → indefinite (remove ال, add tanween)
+3. Apply transformations in sequence
+4. Understand the bidirectional relationship between forms
+
+---
+
+## Template Structure
+
+**Question Format:**
+```
+Complete the transformation sequence:
+
+{starting_form} → {intermediate_form} → {final_form}
+```
+
+**Answer Format:**
+```json
+{
+  "missing_form": "{arabic_with_harakaat}",
+  "explanation": "Brief explanation of transformation"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with both indefinite and definite forms
+- `question_count`: Number of chains to generate (default: 5)
+- `chain_type`: "forward" | "backward" | "mixed" | "full_cycle"
+- `difficulty`: beginner | intermediate | advanced
+
+### Chain Types
+
+**Type 1: Forward (indefinite → definite)**
+```
+كِتَابٌ → _____ (student fills: الْكِتَابُ)
+```
+
+**Type 2: Backward (definite → indefinite)**
+```
+الْكِتَابُ → _____ (student fills: كِتَابٌ)
+```
+
+**Type 3: Full Cycle (indefinite → definite → indefinite)**
+```
+كِتَابٌ → الْكِتَابُ → _____ (student fills: كِتَابٌ)
+Pattern recognition: should return to original form
+```
+
+**Type 4: Extended Chain (multiple steps)**
+```
+كِتَابٌ → _____ → كِتَابٌ → _____ (fills: الْكِتَابُ, الْكِتَابُ)
+Tests understanding of alternation pattern
+```
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Forward - Add ال)
+**Question:** Complete the sequence:
+
+كِتَابٌ (kitaabun - a book) → _____
+
+**Correct Answer:**
+```json
+{
+  "missing_form": "الْكِتَابُ",
+  "explanation": "To make definite: add ال at the beginning and remove tanween (ٌ). Result: الْكِتَابُ (al-kitaabu - the book)"
+}
+```
+
+---
+
+### Question 2 (Backward - Remove ال)
+**Question:** Complete the sequence:
+
+الْمَدْرَسَةُ (al-madrasatu - the school) → _____
+
+**Correct Answer:**
+```json
+{
+  "missing_form": "مَدْرَسَةٌ",
+  "explanation": "To make indefinite: remove ال and add tanween (ٌ). Result: مَدْرَسَةٌ (madrasatun - a school)"
+}
+```
+
+---
+
+### Question 3 (Full Cycle - Pattern Recognition)
+**Question:** Complete the sequence:
+
+طَاوِلَةٌ (taawilatun - a table) → الطَّاوِلَةُ (aT-Taawilatu - the table) → _____
+
+**Correct Answer:**
+```json
+{
+  "missing_form": "طَاوِلَةٌ",
+  "explanation": "Removing ال brings us back to the indefinite form. Add tanween: طَاوِلَةٌ (same as the starting form)"
+}
+```
+
+---
+
+### Question 4 (Extended Chain - Multiple Missing)
+**Question:** Complete the sequence by filling in both blanks:
+
+قَلَمٌ (qalamun) → _____ → قَلَمٌ (qalamun) → _____
+
+**Correct Answer:**
+```json
+{
+  "missing_forms": ["الْقَلَمُ", "الْقَلَمُ"],
+  "explanation": "The pattern alternates: indefinite → definite → indefinite → definite. Both missing forms are الْقَلَمُ (al-qalamu - the pen)"
+}
+```
+
+---
+
+### Question 5 (Challenge - Start with Definite)
+**Question:** Complete the sequence:
+
+_____ → الْبَيْتُ (al-baytu - the house) → بَيْتٌ (baytun - a house)
+
+**Correct Answer:**
+```json
+{
+  "missing_form": "بَيْتٌ",
+  "explanation": "Working backward: if الْبَيْتُ is the middle form (definite), the starting form must be indefinite: بَيْتٌ"
+}
+```
+
+---
+
+### Question 6 (Multi-Step with Context)
+**Question:** Complete all missing forms:
+
+_____ → الْكُرْسِيُّ (al-kursiyyu) → _____ → الْكُرْسِيُّ
+
+**Correct Answer:**
+```json
+{
+  "missing_forms": ["كُرْسِيٌّ", "كُرْسِيٌّ"],
+  "explanation": "Pattern: indefinite → definite → indefinite → definite. Both missing forms are كُرْسِيٌّ (kursiyyun - a chair)"
+}
+```
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Arabic spelling is exact (including all harakaat)
+- Tanween is present on indefinite forms (ٌ)
+- ال is present on definite forms (no tanween)
+- No space between ال and noun
+
+**Common Errors to Accept (with feedback):**
+- Wrong tanween type (ً or ٍ instead of ٌ) → Accept but note "use ٌ for nominative"
+- Missing sukuun on ال (الكِتَابُ instead of الْكِتَابُ) → Accept but note proper form
+
+**Common Errors to Reject:**
+- Has both ال and tanween (conflicting markers)
+- Missing tanween on indefinite form
+- Missing ال on definite form
+- Extra space between ال and noun
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- Single-step chains (A → B only)
+- Always show transliteration
+- One missing form per question
+- Clear direction labels ("add ال" or "remove ال")
+
+**Intermediate (Lessons 2-3):**
+- Two-step chains (A → B → C)
+- Sometimes omit transliteration
+- One missing form in middle or end
+- Mix masculine and feminine nouns
+
+**Advanced (Lessons 4+):**
+- Three+ step chains (A → B → C → D)
+- Multiple missing forms per chain
+- No transliteration or hints
+- Start in middle of sequence (must work backward)
+- Include exception vocabulary
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand chain patterns
+2. **Pull vocabulary** from cached lesson content (need both forms)
+3. **Select chain type** based on difficulty
+4. **Generate sequence** with 1-2 missing forms
+5. **Output JSON**:
+```json
+{
+  "question": "Complete the transformation sequence:",
+  "chain": [
+    {"position": 1, "form": "كِتَابٌ", "transliteration": "kitaabun", "meaning": "a book", "visible": true},
+    {"position": 2, "form": "الْكِتَابُ", "transliteration": "al-kitaabu", "meaning": "the book", "visible": false},
+    {"position": 3, "form": "كِتَابٌ", "transliteration": "kitaabun", "meaning": "a book", "visible": true}
+  ],
+  "correct_answer": {
+    "position_2": "الْكِتَابُ"
+  },
+  "explanation": "Position 2 should be definite form (add ال, remove tanween): الْكِتَابُ"
+}
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Indefinite forms have tanween (ٌ)
+- [ ] Definite forms have ال prefix (no tanween)
+- [ ] Chain follows logical transformation pattern
+- [ ] All vocabulary from current or previous lessons
+- [ ] Explanations clearly state the transformation rule
+
+---
+
+## Pedagogical Notes
+
+**Why this exercise works:**
+- Visual pattern reinforces the transformation rule
+- Shows bidirectional nature (not just one-way)
+- Cycle completion demonstrates understanding
+- Helps students see ال and tanween as mutually exclusive
+
+**Learning progression:**
+1. **Simple forward**: A → B (just adding ال)
+2. **Simple backward**: B → A (just removing ال)
+3. **Full cycle**: A → B → A (seeing the return to original)
+4. **Extended chains**: A → B → A → B (recognizing pattern)
+5. **Missing start**: ___ → B → A (working backward)
+
+**Common misconceptions this reveals:**
+- Student adds ال but keeps tanween → Doesn't understand mutual exclusivity
+- Student removes ال but doesn't add tanween → Forgets indefinite marker
+- Student can't work backward → Only memorized one direction
+
+**Gamification potential:**
+- Speed challenges (complete chain in X seconds)
+- "Chain reaction" mode (automatically advance when correct)
+- Achievement: "Master of Transformation" (10 perfect chains)

--- a/data/rag_database/exercises/transformation_chain_definite_article.md
+++ b/data/rag_database/exercises/transformation_chain_definite_article.md
@@ -113,7 +113,7 @@ Tests understanding of alternation pattern
 ### Question 3 (Full Cycle - Pattern Recognition)
 **Question:** Complete the sequence:
 
-طَاوِلَةٌ (taawilatun - a table) → الطَّاوِلَةُ (aT-Taawilatu - the table) → _____
+طَاوِلَةٌ (taawilatun - a table) → الطَّاوِلَةُ (at-taawilatu - the table) → _____
 
 **Correct Answer:**
 ```json

--- a/data/rag_database/exercises/translation_definite_article.md
+++ b/data/rag_database/exercises/translation_definite_article.md
@@ -122,7 +122,7 @@ c) بَيْتُ
 ### Question 5 (Remove ال)
 **Question:** Translate to Arabic: "a table"
 
-**Given:** الطَّاوِلَةُ (aT-Taawilatu - the table)
+**Given:** الطَّاوِلَةُ (at-taawilatu - the table)
 
 **Correct Answer:** طَاوِلَةٌ
 

--- a/data/rag_database/exercises/translation_definite_article.md
+++ b/data/rag_database/exercises/translation_definite_article.md
@@ -1,0 +1,208 @@
+---
+exercise_type: translation
+grammar_point: definite_article_al
+difficulty: beginner
+lesson_number: 1
+target_skill: adding_removing_definite_article
+---
+
+# Translation Exercise: Definite Article
+
+## Exercise Purpose
+
+Test student's ability to:
+1. Add the definite article ال to nouns (making indefinite → definite)
+2. Remove the definite article (making definite → indefinite)
+3. Understand that tanween (ٌ) disappears when ال is added
+
+---
+
+## Template Structure
+
+**Question Format (Add ال):**
+```
+Translate to Arabic: "the {noun}"
+
+Given the indefinite form: {noun_indefinite}
+```
+
+**Question Format (Remove ال):**
+```
+Translate to Arabic: "a {noun}"
+
+Given the definite form: {noun_definite}
+```
+
+**Answer Format:**
+```json
+{
+  "correct_answer": "{arabic_with_harakaat}",
+  "explanation": "Brief explanation about ال and tanween"
+}
+```
+
+---
+
+## Generation Rules
+
+### Input Requirements
+- `vocabulary_pool`: List of nouns with both indefinite and definite forms
+- `question_count`: Number of questions to generate (default: 5)
+- `direction`: "add_al" | "remove_al" | "mixed"
+
+### Question Generation Logic
+
+**Direction: add_al (indefinite → definite)**
+1. Select noun from vocabulary_pool
+2. Show indefinite form: {noun}ٌ
+3. Ask: "Translate: the {english}"
+4. Expected: ال{noun}ُ (with ال prefix, no tanween)
+
+**Direction: remove_al (definite → indefinite)**
+1. Select noun from vocabulary_pool
+2. Show definite form: ال{noun}ُ
+3. Ask: "Translate: a {english}"
+4. Expected: {noun}ٌ (no ال, with tanween)
+
+**Direction: mixed**
+- Randomly mix add_al and remove_al questions
+- Aim for ~50/50 split
+
+---
+
+## Example Generated Exercise Set
+
+### Question 1 (Add ال)
+**Question:** Translate to Arabic: "the book"
+
+**Given:** كِتَابٌ (kitaabun - a book)
+
+**Correct Answer:** الْكِتَابُ
+
+**Explanation:** To make a noun definite, add ال at the beginning and remove the tanween (ٌ). Result: كِتَابٌ → الْكِتَابُ
+
+---
+
+### Question 2 (Remove ال)
+**Question:** Translate to Arabic: "a school"
+
+**Given:** الْمَدْرَسَةُ (al-madrasatu - the school)
+
+**Correct Answer:** مَدْرَسَةٌ
+
+**Explanation:** To make a noun indefinite, remove ال and add tanween (ٌ) at the end. Result: الْمَدْرَسَةُ → مَدْرَسَةٌ
+
+---
+
+### Question 3 (Add ال)
+**Question:** Translate to Arabic: "the pen"
+
+**Given:** قَلَمٌ (qalamun - a pen)
+
+**Correct Answer:** الْقَلَمُ
+
+**Explanation:** Add ال at the beginning and change tanween (ٌ) to single damma (ُ). Result: قَلَمٌ → الْقَلَمُ
+
+---
+
+### Question 4 (Mixed - identify)
+**Question:** Which one means "the house"?
+
+**Options:**
+a) بَيْتٌ  
+b) الْبَيْتُ  
+c) بَيْتُ
+
+**Correct Answer:** b) الْبَيْتُ
+
+**Explanation:** الْبَيْتُ means "the house" because it has ال (definite article). Option (a) بَيْتٌ means "a house" (indefinite). Option (c) is missing proper harakaat.
+
+---
+
+### Question 5 (Remove ال)
+**Question:** Translate to Arabic: "a table"
+
+**Given:** الطَّاوِلَةُ (aT-Taawilatu - the table)
+
+**Correct Answer:** طَاوِلَةٌ
+
+**Explanation:** Remove ال and add tanween. For feminine nouns ending in ة, add ٌ after the ة: الطَّاوِلَةُ → طَاوِلَةٌ
+
+---
+
+## Grading Criteria
+
+**Correct if:**
+- Arabic text matches expected form exactly
+- Includes proper harakaat (vowel marks)
+- Has tanween (ٌ) for indefinite
+- Has ال prefix for definite (no tanween)
+
+**Common Errors to Accept (with feedback):**
+- Wrong tanween type (ً or ٍ instead of ٌ) → Accept but note "use ٌ for nominative"
+- Missing tanween → Accept but note "add tanween for indefinite"
+- Extra space between ال and noun → Mark wrong, note "attach ال directly"
+
+**Common Errors to Reject:**
+- Missing ال when definite required
+- Including ال when indefinite required
+- Has both ال and tanween (conflicting markers)
+- Missing all harakaat
+
+---
+
+## Adaptive Difficulty
+
+**Beginner (Lesson 1):**
+- Always show the starting form (indefinite or definite)
+- Use only lesson vocabulary
+- Focus on simple transformations (add or remove ال)
+
+**Intermediate (Lessons 2-3):**
+- Sometimes ask without showing starting form
+- Mix vocabulary from multiple lessons
+- Include both masculine and feminine nouns
+
+**Advanced (Lessons 4+):**
+- Use in context: "The big house" → الْبَيْتُ الْكَبِيرُ
+- Test sun letters (ال + ش → الشَّمْس)
+- Combine with other grammar points (pronouns, adjectives)
+
+---
+
+## Agent 3 Implementation Notes
+
+**When generating this exercise type:**
+
+1. **Parse this template** to understand structure
+2. **Pull vocabulary** from cached lesson content (need both indefinite and definite forms)
+3. **Generate 5 questions** with variety:
+   - 2-3 "add ال" questions
+   - 2-3 "remove ال" questions
+   - Mix masculine and feminine nouns
+4. **Output JSON**:
+```json
+[
+  {
+    "question": "Translate to Arabic: 'the book'",
+    "given": "كِتَابٌ (kitaabun - a book)",
+    "correct_answer": "الْكِتَابُ",
+    "explanation": "To make a noun definite, add ال at the beginning and remove the tanween (ٌ)."
+  },
+  {
+    "question": "Translate to Arabic: 'a school'",
+    "given": "الْمَدْرَسَةُ (al-madrasatu - the school)",
+    "correct_answer": "مَدْرَسَةٌ",
+    "explanation": "To make a noun indefinite, remove ال and add tanween (ٌ) at the end."
+  }
+  ...
+]
+```
+
+**Quality checks:**
+- [ ] All Arabic includes proper harakaat and tanween
+- [ ] Indefinite forms have tanween (ٌ)
+- [ ] Definite forms have ال prefix (no tanween)
+- [ ] Mix of add/remove ال questions (~50/50)
+- [ ] Mix of masculine and feminine nouns
+- [ ] All vocabulary from current or previous lessons

--- a/data/rag_database/lessons/lesson_01_gender_definite_article.md
+++ b/data/rag_database/lessons/lesson_01_gender_definite_article.md
@@ -398,7 +398,7 @@ IF indefinite but missing tanween → ERROR
 
 **Correction**: "Indefinite nouns must end with tanween (ٌ). Add ٌ to the end: كِتَابٌ"
 
-### Error Type: tanween_with_definite_article
+### Error Type: al_tanween_conflict
 
 **Pattern**:
 ```
@@ -439,9 +439,9 @@ IF missing harakaat → ERROR
 
 | Indefinite | Definite | Transliteration | English |
 |------------|----------|----------------|---------|
-| طَاوِلَةٌ | الطَّاوِلَةُ | taawilatun / aT-Taawilatu | table / the table |
+| طَاوِلَةٌ | الطَّاوِلَةُ | taawilatun / at-taawilatu | table / the table |
 | مَدْرَسَةٌ | الْمَدْرَسَةُ | madrasatun / al-madrasatu | school / the school |
-| نَافِذَةٌ | النَّافِذَةُ | naafidhatun / an-naafIdhatu | window / the window |
+| نَافِذَةٌ | النَّافِذَةُ | naafidhatun / an-naafidhatu | window / the window |
 | غُرْفَةٌ | الْغُرْفَةُ | ghurfatun / al-ghurfatu | room / the room |
 
 ### Essential Phrases

--- a/data/rag_database/lessons/lesson_01_gender_definite_article.md
+++ b/data/rag_database/lessons/lesson_01_gender_definite_article.md
@@ -1,0 +1,479 @@
+---
+lesson_number: 1
+lesson_name: "Gender and Definite Article"
+grammar_points:
+  - masculine_feminine_nouns
+  - definite_article_al
+prerequisites: []
+difficulty: beginner
+vocabulary:
+  - كِتَابٌ  # kitaabun - book (m)
+  - طَاوِلَةٌ  # taawilatun - table (f)
+  - بَيْتٌ  # baytun - house (m)
+  - مَدْرَسَةٌ  # madrasatun - school (f)
+  - قَلَمٌ  # qalamun - pen (m)
+  - بَابٌ  # baabun - door (m)
+  - كُرْسِيٌّ  # kursiyyun - chair (m)
+  - نَافِذَةٌ  # naafidhatun - window (f)
+  - غُرْفَةٌ  # ghurfatun - room (f)
+  - مَكْتَبٌ  # maktabun - office (m)
+---
+
+# Lesson 1: Gender and Definite Article
+
+## Overview
+
+This lesson introduces two fundamental concepts in Arabic:
+1. **Noun Gender**: Every Arabic noun is either masculine or feminine
+2. **Definite Article**: Using ال (al-) to make nouns definite
+
+These concepts are essential building blocks for all Arabic grammar.
+
+---
+
+## Grammar Point 1: Masculine and Feminine Nouns
+
+### Rule
+
+In Arabic, **both nouns and adjectives** are either **masculine** or **feminine**. The feminine singular is most commonly marked by **ة** (taa marbuuta).
+
+### Human vs. Non-Human Nouns
+
+**Human nouns** (people): Gender comes from the person
+- مُعَلِّمٌ (mu'allimun) - teacher (male) → masculine
+- مُعَلِّمَةٌ (mu'allimatun) - teacher (female) → feminine  
+- طَبِيبٌ (Tabiibun) - doctor (male) → masculine
+- طَبِيبَةٌ (Tabiibatun) - doctor (female) → feminine
+
+**Non-human nouns** (things): Gender is **fixed** and must be **memorized**
+- كِتَابٌ (kitaabun) - book → masculine (doesn't change)
+- طَاوِلَةٌ (taawilatun) - table → feminine (doesn't change)
+- There's no logical reason why "book" is masculine and "table" is feminine - you must learn each one.
+
+### Agreement Rule (Critical!)
+
+The gender of a noun **must match** any words that describe or refer to it:
+- ✓ **Adjectives must agree**: الْبَيْتُ الْكَبِيرُ (the big house - both masculine)
+- ✓ **Pronouns must agree**: هُوَ (he/it for masculine), هِيَ (she/it for feminine)
+- ❌ **Wrong**: الْبَيْتُ الْكَبِيرَةُ (house is masculine but adjective is feminine)
+
+### Examples - Masculine Nouns
+
+**Pattern**: No ة ending (most cases)
+
+**Note**: Shown with tanween (ٌ) for indefinite form
+
+| Arabic (indefinite) | Transliteration | English | Gender |
+|---------------------|----------------|---------|--------|
+| كِتَابٌ | kitaabun | a book | masculine |
+| بَيْتٌ | baytun | a house | masculine |
+| قَلَمٌ | qalamun | a pen | masculine |
+| بَابٌ | baabun | a door | masculine |
+| كُرْسِيٌّ | kursiyyun | a chair | masculine |
+| مَكْتَبٌ | maktabun | an office | masculine |
+
+### Examples - Feminine Nouns
+
+**Pattern**: Ends in ة (taa marbuuta)
+
+**Note**: Shown with tanween (ٌ) for indefinite form
+
+| Arabic (indefinite) | Transliteration | English | Gender |
+|---------------------|----------------|---------|--------|
+| طَاوِلَةٌ | taawilatun | a table | feminine |
+| مَدْرَسَةٌ | madrasatun | a school | feminine |
+| نَافِذَةٌ | naafidhatu | a window | feminine |
+| غُرْفَةٌ | ghurfatun | a room | feminine |
+
+### Key Insight: Taa Marbuuta (ة)
+
+**✓ Most common feminine indicator**: Taa marbuuta (ة) at the end signals feminine  
+**✓ Masculine default**: If no ة, usually masculine  
+**✓ Applies to nouns AND adjectives**: كَبِيرٌ (big, m) vs كَبِيرَةٌ (big, f)
+
+**Note**: All vocabulary in this lesson follows the rule perfectly - all feminine nouns end in ة!
+
+**Important Exception**: Some words are feminine without ة (learned in later lessons). For now, ة = feminine is reliable.
+
+### Detection Pattern (For Grading)
+
+```
+IF word ends in ة → FEMININE
+ELSE → MASCULINE (for Lesson 1 vocabulary)
+```
+
+---
+
+## Grammar Point 2: Definite Article ال (al-)
+
+### Rule
+
+Add **ال** (al-) to the beginning of a noun to make it **definite** (like "the" in English).
+
+**IMPORTANT**: Indefinite nouns end with **tanween** (ٌ ً ٍ - double vowels). When you add ال, the tanween disappears!
+
+### Understanding Tanween (تَنْوِين)
+
+**Tanween** = Double vowel marks at the end of indefinite nouns
+
+Three types (all mean indefinite):
+- **ٌ** (dammatan) - nominative: كِتَابٌ (kitaabun)
+- **ً** (fathatan) - accusative: كِتَابًا (kitaaban) 
+- **ٍ** (kasratan) - genitive: كِتَابٍ (kitaabin)
+
+**For beginners**: Focus on **ٌ** (dammatan) - the most common form
+
+### Examples - Indefinite vs. Definite
+
+**Notice**: Tanween (ٌ) disappears when ال is added!
+
+| Indefinite (with tanween) | Definite (no tanween) | Translation |
+|---------------------------|----------------------|-------------|
+| كِتَابٌ | الْكِتَابُ | a book → **the** book |
+| طَاوِلَةٌ | الطَّاوِلَةُ | a table → **the** table |
+| مَدْرَسَةٌ | الْمَدْرَسَةُ | a school → **the** school |
+| بَيْتٌ | الْبَيْتُ | a house → **the** house |
+| قَلَمٌ | الْقَلَمُ | a pen → **the** pen |
+| غُرْفَةٌ | الْغُرْفَةُ | a room → **the** room |
+
+### Key Insight
+
+**✓ Indefinite = tanween**: كِتَابٌ (kitaabun) has ٌ at the end  
+**✓ Definite = no tanween**: الْكِتَابُ (al-kitaabu) - just single damma ُ  
+**✓ Always prefix**: ال goes at the beginning, never separate  
+**✓ Works with both genders**: ال works for masculine AND feminine nouns
+
+**Visual Pattern**:
+```
+Indefinite: [noun]ٌ   (has tanween)
+Definite:   ال[noun]ُ (no tanween, just damma)
+```
+
+### Agreement Rule: Adjectives Must Match Definiteness
+
+When an adjective describes a noun, it **must match** both gender AND definiteness:
+
+**Indefinite noun + indefinite adjective:**
+- كِتَابٌ كَبِيرٌ (kitaabun kabiir**un**) - a big book (both indefinite with tanween)
+
+**Definite noun + definite adjective:**
+- الْكِتَابُ الْكَبِيرُ (al-kitaab**u** al-kabiir**u**) - the big book (both definite with ال, no tanween)
+
+**❌ Wrong combinations:**
+- ❌ الْكِتَابُ كَبِيرٌ (definite noun + indefinite adjective - mismatch!)
+- ❌ كِتَابٌ الْكَبِيرُ (indefinite noun + definite adjective - mismatch!)
+
+**Both gender AND definiteness must agree between noun and adjective.**
+
+### Common Mistakes
+
+❌ **Wrong**: كِتَابٌ ال (article after noun)  
+✓ **Correct**: الْكِتَابُ (article before noun)
+
+❌ **Wrong**: ال كِتَابٌ (space between)  
+✓ **Correct**: الْكِتَابُ (no space)
+
+❌ **Wrong**: الْكِتَابٌ (keeping tanween with ال)  
+✓ **Correct**: الْكِتَابُ (tanween removed, use single damma)
+
+❌ **Wrong**: كِتَاب (no harakaat)  
+✓ **Correct**: كِتَابٌ (with tanween for indefinite)
+
+### Detection Pattern (For Grading)
+
+```
+IF word starts with ال → DEFINITE (no tanween)
+ELSE IF word ends with tanween (ٌ ً ٍ) → INDEFINITE
+ELSE → INCOMPLETE (missing harakaat)
+```
+
+---
+
+## Combined Practice: Noun-Adjective Agreement
+
+### The Complete Agreement System
+
+For a noun-adjective phrase to be correct, **three things must match**:
+
+1. **Gender**: Masculine noun → masculine adjective (or feminine → feminine)
+2. **Definiteness**: Indefinite noun → indefinite adjective (or definite → definite)
+3. **Word order**: Noun comes FIRST, then adjective
+
+### Examples - All Combinations
+
+| Noun | Adjective | Phrase | Translation |
+|------|-----------|--------|-------------|
+| كِتَابٌ (m, indef) | كَبِيرٌ (m, indef) | كِتَابٌ كَبِيرٌ | a big book ✓ |
+| الْكِتَابُ (m, def) | الْكَبِيرُ (m, def) | الْكِتَابُ الْكَبِيرُ | the big book ✓ |
+| طَاوِلَةٌ (f, indef) | كَبِيرَةٌ (f, indef) | طَاوِلَةٌ كَبِيرَةٌ | a big table ✓ |
+| الطَّاوِلَةُ (f, def) | الْكَبِيرَةُ (f, def) | الطَّاوِلَةُ الْكَبِيرَةُ | the big table ✓ |
+
+### Common Errors
+
+**Error Type 1: Gender mismatch**
+- ❌ كِتَابٌ كَبِيرَةٌ (masculine noun + feminine adjective)
+- ✓ كِتَابٌ كَبِيرٌ (both masculine)
+
+**Error Type 2: Definiteness mismatch**
+- ❌ الْكِتَابُ كَبِيرٌ (definite noun + indefinite adjective)
+- ✓ الْكِتَابُ الْكَبِيرُ (both definite)
+
+**Error Type 3: Word order**
+- ❌ كَبِيرٌ كِتَابٌ (adjective before noun - English order)
+- ✓ كِتَابٌ كَبِيرٌ (noun before adjective - Arabic order)
+
+### Practice Adjectives for Lesson 1
+
+| Masculine | Feminine | English |
+|-----------|----------|---------|
+| كَبِيرٌ | كَبِيرَةٌ | big |
+| صَغِيرٌ | صَغِيرَةٌ | small |
+| جَدِيدٌ | جَدِيدَةٌ | new |
+| قَدِيمٌ | قَدِيمَةٌ | old |
+| جَمِيلٌ | جَمِيلَةٌ | beautiful |
+
+**Note**: All adjectives follow the same pattern - add ة for feminine, add ال for definite (remove tanween).
+
+---
+
+## Essential Phrases
+
+### Greeting: "Hello"
+
+**Arabic**: مَرْحَبًا  
+**Transliteration**: marhaban  
+**English**: Hello
+
+**Usage**: Use this to greet people in Arabic
+
+### Asking "How are you?"
+
+**Arabic**: كَيْفَ حَالُكَ؟  
+**Transliteration**: kayfa haaluka?  
+**English**: How are you? (to a male)
+
+**Note**: This is asking a male. The response could be: أَنَا بِخَيْرٍ (ana bi-khayr) - I am fine.
+
+### Introducing yourself: "My name is..."
+
+**Arabic**: اسْمِي...  
+**Transliteration**: ismii...  
+**English**: My name is...
+
+**Examples**:
+- اسْمِي أَحْمَد (ismii ahmad) - My name is Ahmad
+- اسْمِي فَاطِمَة (ismii faaTima) - My name is Fatima
+
+**Usage with greetings**:
+- مَرْحَبًا! اسْمِي أَحْمَد (marhaban! ismii ahmad) - Hello! My name is Ahmad
+- كَيْفَ حَالُكَ؟ أَنَا بِخَيْرٍ (kayfa haaluka? ana bi-khayr) - How are you? I am fine.
+
+---
+
+## Combined Examples
+
+Understanding both gender AND definite article together:
+
+**Key**: Notice tanween (ٌ) on indefinite, single damma (ُ) on definite
+
+| Arabic | Gender | Definite? | Translation |
+|--------|--------|-----------|-------------|
+| كِتَابٌ | masculine | no | a book |
+| الْكِتَابُ | masculine | yes | the book |
+| طَاوِلَةٌ | feminine | no | a table |
+| الطَّاوِلَةُ | feminine | yes | the table |
+| مَدْرَسَةٌ | feminine | no | a school |
+| الْمَدْرَسَةُ | feminine | yes | the school |
+| بَابٌ | masculine | no | a door |
+| الْبَابُ | masculine | yes | the door |
+
+---
+
+## Practice Patterns
+
+### Pattern 1: Identify Gender
+
+**Given a word, identify if it's masculine or feminine**
+
+Example: مَدْرَسَةٌ → Feminine (ends in ة)  
+Example: قَلَمٌ → Masculine (no ة)
+
+### Pattern 2: Add Definite Article
+
+**Given an indefinite noun, make it definite**
+
+**Remember**: Remove tanween (ٌ) and add ال
+
+Example: كِتَابٌ → الْكِتَابُ  
+Example: طَاوِلَةٌ → الطَّاوِلَةُ
+
+### Pattern 3: Remove Definite Article
+
+**Given a definite noun, make it indefinite**
+
+**Remember**: Remove ال and add tanween (ٌ)
+
+Example: الْكِتَابُ → كِتَابٌ  
+Example: الْمَدْرَسَةُ → مَدْرَسَةٌ
+
+### Pattern 4: Basic Conversation Practice
+
+**Use essential phrases to build simple conversations**
+
+Example conversation:
+- A: مَرْحَبًا! (Hello!)
+- B: مَرْحَبًا! (Hello!)
+- A: كَيْفَ حَالُكَ؟ (How are you?)
+- B: أَنَا بِخَيْرٍ (I am fine)
+- A: اسْمِي أَحْمَد (My name is Ahmad)
+- B: اسْمِي فَاطِمَة (My name is Fatima)
+
+---
+
+## Detection Rules for Agent 2 (Grading)
+
+### Error Type: incorrect_gender_identification
+
+**Pattern**:
+```
+Expected: feminine
+Student said: masculine
+IF word ends in ة → ERROR (student misidentified)
+```
+
+**Correction**: "Words ending in ة are feminine. Look for the ة (taa marbuuta) at the end."
+
+### Error Type: incorrect_definite_article_placement
+
+**Pattern**:
+```
+Expected: الكِتَاب
+Student wrote: كِتَاب ال
+IF article comes after noun → ERROR
+```
+
+**Correction**: "The definite article ال must come before the noun, not after. Write: الكِتَاب"
+
+### Error Type: incorrect_definite_article_spacing
+
+**Pattern**:
+```
+Expected: الكِتَاب
+Student wrote: ال كِتَاب
+IF space between ال and noun → ERROR
+```
+
+**Correction**: "The definite article ال must be attached directly to the noun with no space."
+
+### Error Type: missing_definite_article
+
+**Pattern**:
+```
+Expected: الكِتَاب (definite)
+Student wrote: كِتَاب (indefinite)
+IF ال missing when required → ERROR
+```
+
+**Correction**: "Add ال at the beginning to make the noun definite. The translation is 'the book', not 'a book'."
+
+### Error Type: unnecessary_definite_article
+
+**Pattern**:
+```
+Expected: كِتَابٌ (indefinite)
+Student wrote: الْكِتَابُ (definite)
+IF ال present when not required → ERROR
+```
+
+**Correction**: "Remove ال to make the noun indefinite. The translation is 'a book', not 'the book'. Write: كِتَابٌ with tanween."
+
+### Error Type: missing_tanween
+
+**Pattern**:
+```
+Expected: كِتَابٌ (indefinite)
+Student wrote: كِتَاب (no tanween)
+IF indefinite but missing tanween → ERROR
+```
+
+**Correction**: "Indefinite nouns must end with tanween (ٌ). Add ٌ to the end: كِتَابٌ"
+
+### Error Type: tanween_with_definite_article
+
+**Pattern**:
+```
+Expected: الْكِتَابُ (definite)
+Student wrote: الْكِتَابٌ (has both ال and tanween)
+IF has ال but also has tanween → ERROR
+```
+
+**Correction**: "When a noun has ال (definite), remove the tanween. Write: الْكِتَابُ with just damma (ُ)."
+
+### Error Type: missing_harakaat
+
+**Pattern**:
+```
+Expected: كِتَابٌ or الْكِتَابُ
+Student wrote: كتاب or الكتاب (no vowel marks)
+IF missing harakaat → ERROR
+```
+
+**Correction**: "All Arabic words in this course must include harakaat (vowel marks). Use proper diacritics."
+
+---
+
+## Vocabulary List (Full)
+
+### Masculine Nouns
+
+| Indefinite | Definite | Transliteration | English |
+|------------|----------|----------------|---------|
+| كِتَابٌ | الْكِتَابُ | kitaabun / al-kitaabu | book / the book |
+| بَيْتٌ | الْبَيْتُ | baytun / al-baytu | house / the house |
+| قَلَمٌ | الْقَلَمُ | qalamun / al-qalamu | pen / the pen |
+| بَابٌ | الْبَابُ | baabun / al-baabu | door / the door |
+| كُرْسِيٌّ | الْكُرْسِيُّ | kursiyyun / al-kursiyyu | chair / the chair |
+| مَكْتَبٌ | الْمَكْتَبُ | maktabun / al-maktabu | office / the office |
+
+### Feminine Nouns
+
+| Indefinite | Definite | Transliteration | English |
+|------------|----------|----------------|---------|
+| طَاوِلَةٌ | الطَّاوِلَةُ | taawilatun / aT-Taawilatu | table / the table |
+| مَدْرَسَةٌ | الْمَدْرَسَةُ | madrasatun / al-madrasatu | school / the school |
+| نَافِذَةٌ | النَّافِذَةُ | naafidhatun / an-naafIdhatu | window / the window |
+| غُرْفَةٌ | الْغُرْفَةُ | ghurfatun / al-ghurfatu | room / the room |
+
+### Essential Phrases
+
+| Arabic | Transliteration | English |
+|--------|----------------|---------|
+| مَرْحَبًا | marhaban | Hello |
+| كَيْفَ حَالُكَ؟ | kayfa haaluka? | How are you? (m) |
+| اسْمِي... | ismii... | My name is... |
+
+---
+
+## Success Criteria
+
+After completing this lesson, students should be able to:
+
+1. ✓ Identify whether a noun is masculine or feminine by looking for ة
+2. ✓ Add the definite article ال correctly (before noun, no space, remove tanween)
+3. ✓ Understand tanween (ٌ) as the marker of indefinite nouns
+4. ✓ Translate 10 vocabulary words (6 masculine, 4 feminine)
+5. ✓ Distinguish between indefinite and definite nouns
+6. ✓ Use basic greetings: مَرْحَبًا (hello), كَيْفَ حَالُكَ؟ (how are you?), اسْمِي... (my name is...)
+
+---
+
+## Next Lesson Preview
+
+**Lesson 2: Subject Pronouns & Nominal Sentences**
+
+Once you understand noun gender, you'll learn:
+- How to say "I", "you", "he", "she" in Arabic
+- How to build simple sentences without verbs
+- How pronouns change based on gender
+
+Example: هُوَ طَالِب (He is a student)

--- a/data/rag_database/lessons/lesson_01_gender_definite_article.md
+++ b/data/rag_database/lessons/lesson_01_gender_definite_article.md
@@ -82,7 +82,7 @@ The gender of a noun **must match** any words that describe or refer to it:
 |---------------------|----------------|---------|--------|
 | طَاوِلَةٌ | taawilatun | a table | feminine |
 | مَدْرَسَةٌ | madrasatun | a school | feminine |
-| نَافِذَةٌ | naafidhatu | a window | feminine |
+| نَافِذَةٌ | naafidhatun | a window | feminine |
 | غُرْفَةٌ | ghurfatun | a room | feminine |
 
 ### Key Insight: Taa Marbuuta (ة)


### PR DESCRIPTION
## Summary by Sourcery

Add RAG lesson content for Arabic noun gender and definite article along with a suite of reusable exercise templates for Lesson 1.

New Features:
- Introduce Lesson 1 RAG content covering Arabic noun gender and the definite article with explanations, examples, and detection rules.
- Add multiple reusable exercise templates for Lesson 1, including sentence-level error correction, paradigm tables, cloze grammar rules, noun-adjective agreement, error correction for definite article usage, multiple choice error identification, transformation chains, dictation, pattern recognition, sorting, translation, and fill-in-the-blank exercises.
- Provide a reusability guide documenting how exercise templates can be adapted across grammar points and future lessons.

Documentation:
- Document the reusability strategy for exercise templates in a dedicated guide file to support future grammar topics and lessons.