### PR TITLE
Create RAG ingestion pipeline

### DIFF
--- a/.claude/skills/tests-audit.md
+++ b/.claude/skills/tests-audit.md
@@ -18,6 +18,13 @@ Or audit all test files:
 /tests-audit
 ```
 
+**After completing the audit:**
+- Implement ALL recommendations immediately
+- Remove redundant/weak tests
+- Strengthen tests with false positive risks
+- Consolidate similar tests
+- This ensures test quality improvements are applied, not just documented
+
 ## Audit Criteria
 
 ### 1. False Positive Detection
@@ -47,6 +54,8 @@ Or audit all test files:
 ## Instructions
 
 When auditing tests:
+
+**IMPORTANT: After completing the audit, implement ALL recommendations immediately. This skill includes both audit AND implementation.**
 
 1. **Identify False Positives**
    - Find assertions that would pass even if code is broken

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,16 @@ FINETUNED_MODEL_PATH=./models/qwen2.5-3b-v7
 # ChromaDB
 CHROMADB_PATH=./data/vectorstore
 
+# Pinecone RAG (for production RAG ingestion)
+PINECONE_API_KEY=your-pinecone-api-key-here
+PINECONE_INDEX=arabic-teaching
+PINECONE_CLOUD=aws
+PINECONE_REGION=us-east-1
+
+# Embedding Model Configuration
+EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+EMBEDDING_DIMENSION=384
+
 # Optional: LangSmith (for observability)
 # LANGSMITH_API_KEY=your-key-here
 # LANGSMITH_PROJECT=arabic-teaching

--- a/scripts/ingest_rag_database.py
+++ b/scripts/ingest_rag_database.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Script to ingest RAG database content into Pinecone."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from src.rag.markdown_parser import MarkdownParser  # noqa: E402
+from src.rag.pinecone_client import PineconeClient  # noqa: E402
+from src.rag.rag_ingestion import RAGIngestion  # noqa: E402
+from src.rag.sentence_transformer_client import SentenceTransformerClient  # noqa: E402
+
+
+def main():
+    """Run RAG database ingestion pipeline."""
+    # Load environment variables
+    load_dotenv()
+
+    # Configuration from environment variables with sensible defaults
+    MODEL_NAME = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+    EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIMENSION", "384"))
+    INDEX_NAME = os.getenv("PINECONE_INDEX", "arabic-teaching")
+    PINECONE_CLOUD = os.getenv("PINECONE_CLOUD", "aws")
+    PINECONE_REGION = os.getenv("PINECONE_REGION", "us-east-1")
+
+    print("Initializing RAG ingestion pipeline...")
+    print("=" * 70)
+
+    # Initialize components
+    print("\n1. Initializing Markdown parser...")
+    parser = MarkdownParser()
+
+    print(f"2. Loading embedding model ({MODEL_NAME})...")
+    embedder = SentenceTransformerClient(model_name=MODEL_NAME, dimension=EMBEDDING_DIM)
+
+    print(f"3. Connecting to Pinecone (index: {INDEX_NAME}, {PINECONE_CLOUD}/{PINECONE_REGION})...")
+    vector_db = PineconeClient(
+        index_name=INDEX_NAME,
+        dimension=EMBEDDING_DIM,
+        cloud=PINECONE_CLOUD,
+        region=PINECONE_REGION,
+    )
+
+    # Defensive: Verify dimensions match
+    if embedder.get_dimension() != vector_db.dimension:
+        print("\n❌ ERROR: Dimension mismatch detected!")
+        print(f"   Embedder dimension: {embedder.get_dimension()}")
+        print(f"   Vector DB dimension: {vector_db.dimension}")
+        print("\nPlease ensure EMBEDDING_DIMENSION matches your Pinecone index configuration.")
+        sys.exit(1)
+
+    print("4. Creating ingestion pipeline...")
+    ingestion = RAGIngestion(parser=parser, embedder=embedder, vector_db=vector_db)
+
+    # Process RAG database
+    rag_db_path = project_root / "data" / "rag_database"
+
+    if not rag_db_path.exists():
+        print(f"\nERROR: RAG database not found at {rag_db_path}")
+        sys.exit(1)
+
+    print(f"\n5. Processing RAG database at {rag_db_path}...")
+    print("   This may take a few minutes...")
+    print("-" * 70)
+
+    result = ingestion.process_directory(rag_db_path, show_progress=True, batch_size=100)
+
+    # Print results
+    print("\n" + "=" * 70)
+    print("INGESTION COMPLETE!")
+    print("=" * 70)
+    print(f"Chunks parsed:    {result['chunks_parsed']}")
+    print(f"Vectors created:  {result['vectors_created']}")
+    print(f"Vectors upserted: {result.get('upserted_count', 0)}")
+    print(f"Batches:          {result.get('batches', 0)}")
+
+    # Show mismatch warning if detected
+    if result.get("mismatch", False):
+        print("\n⚠️  WARNING: Mismatch detected between vectors created and upserted!")
+        print("   This may indicate partial failures or duplicate IDs.")
+
+    print("=" * 70)
+
+    # Verify with database stats
+    print("\nVerifying Pinecone index stats...")
+    stats = vector_db.get_stats()
+    print(f"Total vectors in index: {stats.get('total_vector_count', 'unknown')}")
+    print(f"Index dimension:        {stats.get('dimension', 'unknown')}")
+
+    print("\n✅ RAG database ingestion successful!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_rag_content.py
+++ b/scripts/validate_rag_content.py
@@ -46,9 +46,7 @@ def validate_file(file_path: Path) -> dict[str, Any]:
         # Read file
         content = file_path.read_text(encoding="utf-8")
 
-        # Check frontmatter
-        metadata = parser.parse_frontmatter(content)
-        if metadata:
+        if metadata := parser.parse_frontmatter(content):
             result["frontmatter_valid"] = True
             result["metadata"] = metadata
         else:
@@ -161,26 +159,7 @@ def print_validation_result(result: dict[str, Any]) -> None:
 
     # Chunk analysis summary
     if result["chunks"]:
-        sizes = [len(c["text"]) for c in result["chunks"]]
-        print("\n📊 Chunk Analysis:")
-        print(f"   Total chunks: {len(sizes)}")
-        print(
-            f"   Size range: {min(sizes)} - {max(sizes)} chars "
-            f"({min(sizes) // CHARS_PER_TOKEN} - {max(sizes) // CHARS_PER_TOKEN} tokens)"
-        )
-
-        # Distribution
-        optimal = sum(1 for s in sizes if CHUNK_MIN_OPTIMAL <= s <= CHUNK_MAX_OPTIMAL)
-        if optimal == len(sizes):
-            print(
-                f"   ✅ All chunks in optimal range ({CHUNK_MIN_OPTIMAL}-{CHUNK_MAX_OPTIMAL} chars)"
-            )
-        else:
-            print(
-                f"   {optimal}/{len(sizes)} chunks in optimal range "
-                f"({CHUNK_MIN_OPTIMAL}-{CHUNK_MAX_OPTIMAL} chars)"
-            )
-
+        _print_chunk_analysis(result)
     # Issues
     if result["issues"]:
         print("\n❌ Issues Found:")
@@ -205,6 +184,27 @@ def print_validation_result(result: dict[str, Any]) -> None:
     print("━" * 60)
 
 
+def _print_chunk_analysis(result: dict[str, Any]) -> None:
+    """Print chunk size analysis and distribution."""
+    sizes = [len(c["text"]) for c in result["chunks"]]
+    print("\n📊 Chunk Analysis:")
+    print(f"   Total chunks: {len(sizes)}")
+    print(
+        f"   Size range: {min(sizes)} - {max(sizes)} chars "
+        f"({min(sizes) // CHARS_PER_TOKEN} - {max(sizes) // CHARS_PER_TOKEN} tokens)"
+    )
+
+    # Distribution
+    optimal = sum(CHUNK_MIN_OPTIMAL <= s <= CHUNK_MAX_OPTIMAL for s in sizes)
+    if optimal == len(sizes):
+        print(f"   ✅ All chunks in optimal range ({CHUNK_MIN_OPTIMAL}-{CHUNK_MAX_OPTIMAL} chars)")
+    else:
+        print(
+            f"   {optimal}/{len(sizes)} chunks in optimal range "
+            f"({CHUNK_MIN_OPTIMAL}-{CHUNK_MAX_OPTIMAL} chars)"
+        )
+
+
 def validate_directory(directory: Path) -> None:
     """Validate all .md files in a directory."""
 
@@ -225,9 +225,9 @@ def validate_directory(directory: Path) -> None:
     print("SUMMARY")
     print("=" * 60)
 
-    pass_count = sum(1 for r in results if r["status"] == "PASS")
-    warning_count = sum(1 for r in results if r["status"] == "WARNING")
-    fail_count = sum(1 for r in results if r["status"] == "FAIL")
+    pass_count = sum(r["status"] == "PASS" for r in results)
+    warning_count = sum(r["status"] == "WARNING" for r in results)
+    fail_count = sum(r["status"] == "FAIL" for r in results)
 
     print(f"Total files: {len(results)}")
     print(f"✅ Pass: {pass_count}")

--- a/src/rag/embedding_model.py
+++ b/src/rag/embedding_model.py
@@ -1,0 +1,41 @@
+"""Abstract interface for embedding model operations."""
+
+from typing import Protocol
+
+
+class EmbeddingModel(Protocol):
+    """Protocol defining the interface for embedding model operations."""
+
+    def embed(self, text: str) -> list[float]:
+        """
+        Generate embedding for a single text.
+
+        Args:
+            text: Text to embed
+
+        Returns:
+            List of floats representing the embedding vector
+        """
+        ...
+
+    def embed_batch(self, texts: list[str], show_progress: bool = False) -> list[list[float]]:
+        """
+        Generate embeddings for multiple texts.
+
+        Args:
+            texts: List of texts to embed
+            show_progress: Show progress bar during embedding
+
+        Returns:
+            List of embedding vectors
+        """
+        ...
+
+    def get_dimension(self) -> int:
+        """
+        Get the dimension of embedding vectors.
+
+        Returns:
+            Embedding dimension
+        """
+        ...

--- a/src/rag/markdown_parser.py
+++ b/src/rag/markdown_parser.py
@@ -199,9 +199,9 @@ class MarkdownParser:
         all_chunks = []
 
         # Use rglob for recursive search, glob for non-recursive
-        pattern = "**/*.md" if recursive else "*.md"
+        file_paths = directory.rglob("*.md") if recursive else directory.glob("*.md")
 
-        for file_path in directory.glob(pattern):
+        for file_path in file_paths:
             try:
                 chunks = self.parse_file(file_path)
                 all_chunks.extend(chunks)

--- a/src/rag/markdown_parser.py
+++ b/src/rag/markdown_parser.py
@@ -185,19 +185,23 @@ class MarkdownParser:
 
         return chunks
 
-    def parse_directory(self, directory: Path) -> list[dict[str, Any]]:
+    def parse_directory(self, directory: Path, recursive: bool = True) -> list[dict[str, Any]]:
         """
         Parse all markdown files in a directory.
 
         Args:
             directory: Path to directory containing markdown files
+            recursive: If True, search subdirectories recursively
 
         Returns:
             List of all chunks from all files
         """
         all_chunks = []
 
-        for file_path in directory.glob("*.md"):
+        # Use rglob for recursive search, glob for non-recursive
+        pattern = "**/*.md" if recursive else "*.md"
+
+        for file_path in directory.glob(pattern):
             try:
                 chunks = self.parse_file(file_path)
                 all_chunks.extend(chunks)

--- a/src/rag/rag_ingestion.py
+++ b/src/rag/rag_ingestion.py
@@ -162,7 +162,7 @@ class RAGIngestion:
 
     def _generate_vector_id(self, chunk: dict[str, Any]) -> str:
         """
-        Generate deterministic ID for a chunk.
+        Generate deterministic unique ID for a chunk.
 
         Args:
             chunk: Chunk with text and metadata
@@ -170,10 +170,12 @@ class RAGIngestion:
         Returns:
             Unique ID string
         """
-        # Create ID from source file and section title
+        # Create ID from source file, section title, and text content hash
+        # This ensures uniqueness even for multiple chunks from the same section
         source = chunk["metadata"].get("source_file", "unknown")
         section = chunk["metadata"].get("section_title", "unknown")
-        id_string = f"{source}::{section}"
+        text_hash = hashlib.sha256(chunk["text"].encode()).hexdigest()[:8]
+        id_string = f"{source}::{section}::{text_hash}"
 
         # Use hash for deterministic, short IDs
         return hashlib.sha256(id_string.encode()).hexdigest()[:16]

--- a/src/rag/rag_ingestion.py
+++ b/src/rag/rag_ingestion.py
@@ -1,0 +1,179 @@
+"""RAG ingestion pipeline for processing and uploading documents to vector database."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from src.rag.embedding_model import EmbeddingModel
+from src.rag.markdown_parser import MarkdownParser
+from src.rag.vector_database import VectorDatabase
+
+logger = logging.getLogger(__name__)
+
+
+class RAGIngestion:
+    """Pipeline for ingesting RAG documents into vector database."""
+
+    def __init__(
+        self,
+        parser: MarkdownParser,
+        embedder: EmbeddingModel,
+        vector_db: VectorDatabase,
+    ):
+        """
+        Initialize RAG ingestion pipeline.
+
+        Args:
+            parser: Markdown parser for extracting chunks
+            embedder: Embedding model for generating vectors
+            vector_db: Vector database for storing embeddings
+        """
+        self.parser = parser
+        self.embedder = embedder
+        self.vector_db = vector_db
+
+    def process_directory(
+        self,
+        directory: Path,
+        show_progress: bool = False,
+        batch_size: int = 100,
+    ) -> dict[str, Any]:
+        """
+        Process all markdown files in directory and upload to vector database.
+
+        Args:
+            directory: Directory containing markdown files
+            show_progress: Show progress bar during embedding
+            batch_size: Batch size for vector database upload
+
+        Returns:
+            Dict with processing statistics
+        """
+        # Parse all markdown files
+        chunks = self.parser.parse_directory(directory)
+
+        if not chunks:
+            return {
+                "chunks_parsed": 0,
+                "vectors_created": 0,
+            }
+
+        # Extract texts for embedding
+        texts = [chunk["text"] for chunk in chunks]
+
+        # Generate embeddings
+        embeddings = self.embedder.embed_batch(texts, show_progress=show_progress)
+
+        # Create vectors with metadata
+        vectors = self._create_vectors_from_chunks(chunks, embeddings)
+
+        # Upload to vector database
+        upsert_result = self.vector_db.upsert(vectors, batch_size=batch_size)
+
+        # Handle API response with proper error detection
+        upserted_count = upsert_result.get("upserted_count")
+        if upserted_count is None:
+            logger.warning(
+                "Vector database did not return upserted_count, using vectors_created as fallback"
+            )
+            upserted_count = len(vectors)
+
+        # Detect potential issues with partial failures
+        mismatch = upserted_count != len(vectors)
+        if mismatch:
+            logger.warning(
+                f"Upsert mismatch detected: created {len(vectors)} vectors, "
+                f"but upserted {upserted_count}"
+            )
+
+        return {
+            "chunks_parsed": len(chunks),
+            "vectors_created": len(vectors),
+            "upserted_count": upserted_count,
+            "batches": upsert_result.get("batches", 0),
+            "mismatch": mismatch,
+        }
+
+    def _create_vectors_from_chunks(
+        self, chunks: list[dict[str, Any]], embeddings: list[list[float]]
+    ) -> list[dict[str, Any]]:
+        """
+        Create vector database entries from chunks and embeddings.
+
+        Args:
+            chunks: Parsed chunks with text and metadata
+            embeddings: Embedding vectors
+
+        Returns:
+            List of vectors ready for upload
+        """
+        vectors = []
+        for chunk, embedding in zip(chunks, embeddings, strict=True):
+            # Sanitize metadata for Pinecone (only supports simple types)
+            sanitized_metadata = self._sanitize_metadata(chunk["metadata"])
+            sanitized_metadata["text"] = chunk["text"]
+
+            vector = {
+                "id": self._generate_vector_id(chunk),
+                "values": embedding,
+                "metadata": sanitized_metadata,
+            }
+            vectors.append(vector)
+
+        return vectors
+
+    def _sanitize_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        """
+        Sanitize metadata to only contain Pinecone-compatible types.
+
+        Pinecone supports: str, int, float, bool, list of str.
+        Complex types (dicts, lists of dicts, etc.) are converted to JSON strings.
+
+        Args:
+            metadata: Original metadata dict
+
+        Returns:
+            Sanitized metadata dict
+        """
+        sanitized = {}
+        for key, value in metadata.items():
+            if value is None:
+                # Skip None values
+                continue
+            elif isinstance(value, str | int | float | bool):
+                # Simple types are fine
+                sanitized[key] = value
+            elif isinstance(value, list):
+                # Check if it's a list of strings
+                if all(isinstance(item, str) for item in value):
+                    sanitized[key] = value
+                else:
+                    # Convert complex lists to JSON string
+                    sanitized[key] = json.dumps(value)
+            else:
+                # Convert complex types (dicts, etc.) to JSON string
+                sanitized[key] = json.dumps(value)
+
+        return sanitized
+
+    def _generate_vector_id(self, chunk: dict[str, Any]) -> str:
+        """
+        Generate deterministic ID for a chunk.
+
+        Args:
+            chunk: Chunk with text and metadata
+
+        Returns:
+            Unique ID string
+        """
+        # Create ID from source file and section title
+        source = chunk["metadata"].get("source_file", "unknown")
+        section = chunk["metadata"].get("section_title", "unknown")
+        id_string = f"{source}::{section}"
+
+        # Use hash for deterministic, short IDs
+        return hashlib.sha256(id_string.encode()).hexdigest()[:16]

--- a/src/rag/sentence_transformer_client.py
+++ b/src/rag/sentence_transformer_client.py
@@ -58,8 +58,7 @@ class SentenceTransformerClient:
         # Convert numpy arrays to lists if needed
         if hasattr(embeddings, "tolist"):
             return embeddings.tolist()
-
-        return list(embeddings)
+        return embeddings
 
     def get_dimension(self) -> int:
         """

--- a/src/rag/sentence_transformer_client.py
+++ b/src/rag/sentence_transformer_client.py
@@ -1,0 +1,71 @@
+"""SentenceTransformer-based embedding client."""
+
+from __future__ import annotations
+
+from sentence_transformers import SentenceTransformer
+
+
+class SentenceTransformerClient:
+    """Client for generating embeddings using SentenceTransformers."""
+
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        dimension: int = 384,
+    ):
+        """
+        Initialize SentenceTransformer client.
+
+        Args:
+            model_name: HuggingFace model name
+            dimension: Expected embedding dimension
+        """
+        self.model_name = model_name
+        self.dimension = dimension
+        self.model = SentenceTransformer(model_name)
+
+    def embed(self, text: str) -> list[float]:
+        """
+        Generate embedding for a single text.
+
+        Args:
+            text: Text to embed
+
+        Returns:
+            List of floats representing the embedding vector
+        """
+        embeddings = self.model.encode([text], convert_to_numpy=False, show_progress_bar=False)
+        return embeddings[0]
+
+    def embed_batch(self, texts: list[str], show_progress: bool = False) -> list[list[float]]:
+        """
+        Generate embeddings for multiple texts.
+
+        Args:
+            texts: List of texts to embed
+            show_progress: Show progress bar during embedding
+
+        Returns:
+            List of embedding vectors
+        """
+        if not texts:
+            return []
+
+        embeddings = self.model.encode(
+            texts, convert_to_numpy=False, show_progress_bar=show_progress
+        )
+
+        # Convert numpy arrays to lists if needed
+        if hasattr(embeddings, "tolist"):
+            return embeddings.tolist()
+
+        return list(embeddings)
+
+    def get_dimension(self) -> int:
+        """
+        Get the dimension of embedding vectors.
+
+        Returns:
+            Embedding dimension
+        """
+        return self.dimension

--- a/src/rag/sentence_transformer_client.py
+++ b/src/rag/sentence_transformer_client.py
@@ -56,9 +56,7 @@ class SentenceTransformerClient:
         )
 
         # Convert numpy arrays to lists if needed
-        if hasattr(embeddings, "tolist"):
-            return embeddings.tolist()
-        return embeddings
+        return embeddings.tolist() if hasattr(embeddings, "tolist") else embeddings
 
     def get_dimension(self) -> int:
         """

--- a/tests/rag/test_markdown_parser.py
+++ b/tests/rag/test_markdown_parser.py
@@ -225,6 +225,64 @@ Content.
         lesson_numbers = {c["metadata"]["lesson_number"] for c in chunks}
         assert lesson_numbers == {1, 2}
 
+    def test_parse_directory_recursive(self, parser, tmp_path):
+        """Test parsing directory recursively finds files in subdirectories."""
+        # Create files in root
+        (tmp_path / "root.md").write_text("""---
+lesson_number: 1
+---
+# Root
+## Section
+Content.
+""")
+
+        # Create subdirectory with files
+        subdir = tmp_path / "lessons"
+        subdir.mkdir()
+        (subdir / "lesson_01.md").write_text("""---
+lesson_number: 2
+---
+# Lesson 1
+## Section
+Content.
+""")
+
+        # Recursive search (default)
+        chunks = parser.parse_directory(tmp_path, recursive=True)
+
+        assert len(chunks) == 2
+        lesson_numbers = {c["metadata"]["lesson_number"] for c in chunks}
+        assert lesson_numbers == {1, 2}
+
+    def test_parse_directory_non_recursive(self, parser, tmp_path):
+        """Test parsing directory non-recursively only finds files in root."""
+        # Create files in root
+        (tmp_path / "root.md").write_text("""---
+lesson_number: 1
+---
+# Root
+## Section
+Content.
+""")
+
+        # Create subdirectory with files
+        subdir = tmp_path / "lessons"
+        subdir.mkdir()
+        (subdir / "lesson_01.md").write_text("""---
+lesson_number: 2
+---
+# Lesson 1
+## Section
+Content.
+""")
+
+        # Non-recursive search
+        chunks = parser.parse_directory(tmp_path, recursive=False)
+
+        # Should only find root.md
+        assert len(chunks) == 1
+        assert chunks[0]["metadata"]["lesson_number"] == 1
+
     def test_chunk_long_content(self, parser):
         """Test chunking long content splits at paragraph boundaries."""
         short_p1 = "Paragraph 1."

--- a/tests/rag/test_rag_ingestion.py
+++ b/tests/rag/test_rag_ingestion.py
@@ -135,6 +135,30 @@ class TestRAGIngestion:
         # Same chunk should produce same ID (deterministic)
         assert ingestion._generate_vector_id(chunk1) == id1
 
+    def test_generate_vector_id_same_section_different_text(
+        self, mock_parser, mock_embedder, mock_vector_db
+    ):
+        """Test vector IDs are unique even for multiple chunks from same section."""
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        # Multiple chunks from same section (e.g., from chunking long content)
+        chunk1 = {
+            "text": "First part of content",
+            "metadata": {"source_file": "file1.md", "section_title": "Intro"},
+        }
+        chunk2 = {
+            "text": "Second part of content",
+            "metadata": {"source_file": "file1.md", "section_title": "Intro"},
+        }
+
+        id1 = ingestion._generate_vector_id(chunk1)
+        id2 = ingestion._generate_vector_id(chunk2)
+
+        # IDs must be different to avoid collision
+        assert id1 != id2
+
     def test_create_vectors_from_chunks(self, mock_parser, mock_embedder, mock_vector_db):
         """Test vector creation from chunks."""
         ingestion = RAGIngestion(
@@ -182,12 +206,17 @@ class TestRAGIngestion:
             "dict_field": {"key": "value"},
             "list_of_dicts": [{"a": 1}, {"b": 2}],
             "mixed_list": ["string", 123, {"nested": "dict"}],
+            "str_list": ["a", "b", "c"],
         }
 
         sanitized = ingestion._sanitize_metadata(metadata)
 
         # Simple types pass through
         assert sanitized["simple"] == "test"
+
+        # list[str] should be preserved, not JSON-encoded
+        assert "str_list" in sanitized
+        assert sanitized["str_list"] == ["a", "b", "c"]
 
         # Verify complex types are converted to valid JSON (round-trip test)
         assert json.loads(sanitized["dict_field"]) == {"key": "value"}

--- a/tests/rag/test_rag_ingestion.py
+++ b/tests/rag/test_rag_ingestion.py
@@ -1,0 +1,250 @@
+"""Tests for RAG ingestion pipeline."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from src.rag.rag_ingestion import RAGIngestion
+
+
+class TestRAGIngestion:
+    """Test suite for RAGIngestion."""
+
+    @pytest.fixture
+    def mock_parser(self):
+        """Fixture for mocked MarkdownParser."""
+        mock = Mock()
+        mock.parse_directory.return_value = [
+            {
+                "text": "Section 1\n\nContent 1",
+                "metadata": {
+                    "lesson_number": 1,
+                    "lesson_name": "Test",
+                    "section_title": "Section 1",
+                    "source_file": "lesson_01.md",
+                    "doc_type": "lesson",
+                },
+            },
+            {
+                "text": "Section 2\n\nContent 2",
+                "metadata": {
+                    "lesson_number": 1,
+                    "lesson_name": "Test",
+                    "section_title": "Section 2",
+                    "source_file": "lesson_01.md",
+                    "doc_type": "lesson",
+                },
+            },
+        ]
+        return mock
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Fixture for mocked embedding model."""
+        mock = Mock()
+        mock.embed_batch.return_value = [[0.1] * 384, [0.2] * 384]
+        mock.get_dimension.return_value = 384
+        return mock
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        """Fixture for mocked vector database."""
+        mock = Mock()
+        mock.upsert.return_value = {
+            "batches": 1,
+            "total_vectors": 2,
+            "upserted_count": 2,
+        }
+        return mock
+
+    def test_process_directory(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test processing directory end-to-end."""
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        result = ingestion.process_directory(Path("data/rag_database"))
+
+        # Verify parser was called
+        mock_parser.parse_directory.assert_called_once_with(Path("data/rag_database"))
+
+        # Verify embedder was called with texts
+        mock_embedder.embed_batch.assert_called_once()
+        texts_arg = mock_embedder.embed_batch.call_args[0][0]
+        assert texts_arg == ["Section 1\n\nContent 1", "Section 2\n\nContent 2"]
+
+        # Verify vector_db was called with vectors
+        mock_vector_db.upsert.assert_called_once()
+        vectors_arg = mock_vector_db.upsert.call_args[0][0]
+        assert len(vectors_arg) == 2
+        assert vectors_arg[0]["values"] == [0.1] * 384
+        assert vectors_arg[1]["values"] == [0.2] * 384
+        assert vectors_arg[0]["metadata"]["lesson_number"] == 1
+        assert vectors_arg[0]["metadata"]["section_title"] == "Section 1"
+
+        # Verify result
+        assert result["chunks_parsed"] == 2
+        assert result["vectors_created"] == 2
+        assert result["upserted_count"] == 2
+        assert result["mismatch"] is False
+
+    def test_process_directory_empty(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test processing directory with no chunks."""
+        mock_parser.parse_directory.return_value = []
+
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        result = ingestion.process_directory(Path("data/rag_database"))
+
+        assert result["chunks_parsed"] == 0
+        assert result["vectors_created"] == 0
+        mock_embedder.embed_batch.assert_not_called()
+        mock_vector_db.upsert.assert_not_called()
+
+    def test_generate_vector_id(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test vector ID generation is deterministic and unique."""
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        chunk1 = {
+            "text": "Test",
+            "metadata": {"source_file": "file1.md", "section_title": "Intro"},
+        }
+        chunk2 = {
+            "text": "Test",
+            "metadata": {"source_file": "file1.md", "section_title": "Body"},
+        }
+        chunk3 = {
+            "text": "Test",
+            "metadata": {"source_file": "file2.md", "section_title": "Intro"},
+        }
+
+        id1 = ingestion._generate_vector_id(chunk1)
+        id2 = ingestion._generate_vector_id(chunk2)
+        id3 = ingestion._generate_vector_id(chunk3)
+
+        # IDs should be different for different chunks
+        assert id1 != id2
+        assert id1 != id3
+        assert id2 != id3
+
+        # Same chunk should produce same ID (deterministic)
+        assert ingestion._generate_vector_id(chunk1) == id1
+
+    def test_create_vectors_from_chunks(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test vector creation from chunks."""
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        chunks = [
+            {
+                "text": "Text 1",
+                "metadata": {"source_file": "f1.md", "section_title": "S1"},
+            },
+            {
+                "text": "Text 2",
+                "metadata": {"source_file": "f2.md", "section_title": "S2"},
+            },
+        ]
+        embeddings = [[0.1] * 384, [0.2] * 384]
+
+        vectors = ingestion._create_vectors_from_chunks(chunks, embeddings)
+
+        assert len(vectors) == 2
+        # Verify ID is a non-empty string (not just non-None)
+        assert vectors[0]["id"]
+        assert isinstance(vectors[0]["id"], str)
+        assert len(vectors[0]["id"]) > 0
+        assert vectors[0]["values"] == [0.1] * 384
+        assert vectors[0]["metadata"] == {
+            "source_file": "f1.md",
+            "section_title": "S1",
+            "text": "Text 1",
+        }
+        assert vectors[1]["values"] == [0.2] * 384
+        assert vectors[1]["metadata"]["text"] == "Text 2"
+
+    def test_sanitize_metadata_complex_types(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test metadata sanitization converts complex types to valid JSON."""
+        import json
+
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        metadata = {
+            "simple": "test",
+            "dict_field": {"key": "value"},
+            "list_of_dicts": [{"a": 1}, {"b": 2}],
+            "mixed_list": ["string", 123, {"nested": "dict"}],
+        }
+
+        sanitized = ingestion._sanitize_metadata(metadata)
+
+        # Simple types pass through
+        assert sanitized["simple"] == "test"
+
+        # Verify complex types are converted to valid JSON (round-trip test)
+        assert json.loads(sanitized["dict_field"]) == {"key": "value"}
+        assert json.loads(sanitized["list_of_dicts"]) == [{"a": 1}, {"b": 2}]
+        assert json.loads(sanitized["mixed_list"]) == ["string", 123, {"nested": "dict"}]
+
+    def test_sanitize_metadata_skips_none(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test metadata sanitization skips None values."""
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        metadata = {"field1": "value", "field2": None, "field3": "another"}
+
+        sanitized = ingestion._sanitize_metadata(metadata)
+
+        assert "field1" in sanitized
+        assert "field2" not in sanitized
+        assert "field3" in sanitized
+
+    def test_process_directory_mismatch_detection(self, mock_parser, mock_embedder, mock_vector_db):
+        """Test mismatch detection when upserted count differs from vectors created."""
+        # Mock upsert to return different count than vectors created
+        mock_vector_db.upsert.return_value = {
+            "batches": 1,
+            "total_vectors": 2,
+            "upserted_count": 1,  # Mismatch: only 1 upserted instead of 2
+        }
+
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        result = ingestion.process_directory(Path("data/rag_database"))
+
+        # Verify mismatch is detected
+        assert result["vectors_created"] == 2
+        assert result["upserted_count"] == 1
+        assert result["mismatch"] is True
+
+    def test_process_directory_missing_upserted_count(
+        self, mock_parser, mock_embedder, mock_vector_db
+    ):
+        """Test handling when API doesn't return upserted_count."""
+        # Mock upsert to return response without upserted_count
+        mock_vector_db.upsert.return_value = {
+            "batches": 1,
+            "total_vectors": 2,
+            # Missing upserted_count
+        }
+
+        ingestion = RAGIngestion(
+            parser=mock_parser, embedder=mock_embedder, vector_db=mock_vector_db
+        )
+
+        result = ingestion.process_directory(Path("data/rag_database"))
+
+        # Verify fallback to vectors_created
+        assert result["upserted_count"] == 2  # Falls back to vectors_created
+        assert result["mismatch"] is False

--- a/tests/rag/test_sentence_transformer_client.py
+++ b/tests/rag/test_sentence_transformer_client.py
@@ -1,0 +1,79 @@
+"""Tests for SentenceTransformer embedding client."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.rag.sentence_transformer_client import SentenceTransformerClient
+
+
+class TestSentenceTransformerClient:
+    """Test suite for SentenceTransformerClient."""
+
+    @pytest.fixture
+    def mock_model(self):
+        """Fixture for mocked SentenceTransformer model."""
+        with patch("src.rag.sentence_transformer_client.SentenceTransformer") as mock_st_class:
+            mock_model = Mock()
+            mock_st_class.return_value = mock_model
+            # Mock encode to return dummy embeddings
+            mock_model.encode.return_value = [[0.1] * 384, [0.2] * 384]
+            yield {"model_class": mock_st_class, "model": mock_model}
+
+    def test_embed_single_text(self, mock_model):
+        """Test embedding a single text string."""
+        # Mock encode to return single embedding
+        mock_model["model"].encode.return_value = [[0.5] * 384]
+
+        client = SentenceTransformerClient()
+        embedding = client.embed("This is a test")
+
+        assert len(embedding) == 384
+        assert embedding == [0.5] * 384
+        mock_model["model"].encode.assert_called_once_with(
+            ["This is a test"], convert_to_numpy=False, show_progress_bar=False
+        )
+
+    def test_embed_batch_texts(self, mock_model):
+        """Test embedding a batch of texts."""
+        # Mock encode to return multiple embeddings
+        mock_model["model"].encode.return_value = [
+            [0.1] * 384,
+            [0.2] * 384,
+            [0.3] * 384,
+        ]
+
+        client = SentenceTransformerClient()
+        texts = ["Text 1", "Text 2", "Text 3"]
+        embeddings = client.embed_batch(texts)
+
+        assert len(embeddings) == 3
+        assert all(len(emb) == 384 for emb in embeddings)
+        assert embeddings[0] == [0.1] * 384
+        assert embeddings[1] == [0.2] * 384
+        assert embeddings[2] == [0.3] * 384
+        mock_model["model"].encode.assert_called_once_with(
+            texts, convert_to_numpy=False, show_progress_bar=False
+        )
+
+    def test_embed_batch_empty_list(self, mock_model):
+        """Test embedding empty list returns empty list."""
+        client = SentenceTransformerClient()
+        embeddings = client.embed_batch([])
+
+        assert embeddings == []
+        mock_model["model"].encode.assert_not_called()
+
+    def test_embed_batch_normalizes_to_list(self, mock_model):
+        """Test that numpy arrays are converted to lists."""
+        import numpy as np
+
+        # Mock encode to return numpy array
+        mock_model["model"].encode.return_value = np.array([[0.1] * 384, [0.2] * 384])
+
+        client = SentenceTransformerClient()
+        embeddings = client.embed_batch(["Text 1", "Text 2"])
+
+        # Should be converted to Python lists
+        assert isinstance(embeddings, list)
+        assert all(isinstance(emb, list) for emb in embeddings)


### PR DESCRIPTION
## Summary by Sourcery

Add a RAG ingestion pipeline for processing markdown lessons into vector embeddings and uploading them to Pinecone, along with supporting embedding abstractions and tests.

New Features:
- Introduce a RAGIngestion pipeline class to parse markdown content, generate embeddings, and upsert vectors into a vector database with basic stats and mismatch detection.
- Add a SentenceTransformerClient implementation of an embedding model plus an EmbeddingModel protocol abstraction.
- Provide a CLI script to ingest the RAG markdown database into a Pinecone index using environment-based configuration.

Enhancements:
- Extend the markdown parser to optionally recurse into subdirectories when parsing markdown files.
- Clarify the tests-audit skill documentation to require implementing audit recommendations immediately.

Documentation:
- Update tests-audit skill documentation with guidance to implement audit recommendations after completion.

Tests:
- Add unit tests for the RAGIngestion pipeline covering end-to-end processing, vector ID generation, metadata sanitization, and upsert result handling.
- Add unit tests for the SentenceTransformerClient covering single and batch embeddings, empty inputs, and numpy-to-list normalization.