### PR TITLE
Retrieve RAG content

### DIFF
--- a/scripts/test_rag_retrieval.py
+++ b/scripts/test_rag_retrieval.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Test script for RAG retrieval against real Pinecone data."""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from src.rag.pinecone_client import PineconeClient  # noqa: E402
+from src.rag.rag_retriever import RAGRetriever  # noqa: E402
+from src.rag.sentence_transformer_client import SentenceTransformerClient  # noqa: E402
+
+
+def main():
+    """Test RAG retrieval with sample queries."""
+    load_dotenv()
+
+    print("Initializing RAG retrieval system...")
+    print("=" * 70)
+
+    # Initialize components
+    embedder = SentenceTransformerClient(
+        model_name="sentence-transformers/all-MiniLM-L6-v2", dimension=384
+    )
+    vector_db = PineconeClient(index_name="arabic-teaching", dimension=384)
+    retriever = RAGRetriever(embedder=embedder, vector_db=vector_db)
+
+    # Test queries
+    test_queries = [
+        ("What is noun gender in Arabic?", 3),
+        ("How do I use the definite article?", 3),
+        ("Explain masculine and feminine nouns", 2),
+    ]
+
+    for query, top_k in test_queries:
+        print(f"\n{'=' * 70}")
+        print(f"Query: {query}")
+        print(f"Top-{top_k} Results:")
+        print("-" * 70)
+
+        results = retriever.retrieve(query, top_k=top_k, min_score=0.5)
+
+        if not results:
+            print("No results found (score >= 0.5)")
+            continue
+
+        for i, result in enumerate(results, 1):
+            print(f"\n[{i}] Score: {result['score']:.3f}")
+            print(f"Source: {result['metadata'].get('source_file', 'unknown')}")
+            print(f"Section: {result['metadata'].get('section_title', 'unknown')}")
+            print(f"Text: {result['text'][:150]}...")
+
+    # Test filtering by lesson
+    print(f"\n{'=' * 70}")
+    print("Testing lesson filtering...")
+    print("-" * 70)
+    print("Query: 'gender' | Lesson: 1 | Top-3")
+
+    results = retriever.retrieve_by_lesson("gender", lesson_number=1, top_k=3)
+    print(f"Found {len(results)} results from lesson 1")
+    for i, result in enumerate(results[:2], 1):
+        print(f"  [{i}] {result['metadata'].get('section_title')} (score: {result['score']:.3f})")
+
+    print(f"\n{'=' * 70}")
+    print("✅ RAG retrieval test complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rag/rag_retriever.py
+++ b/src/rag/rag_retriever.py
@@ -26,7 +26,7 @@ class RAGRetriever:
         self,
         query: str,
         top_k: int = 5,
-        filter: dict[str, Any] | None = None,
+        metadata_filter: dict[str, Any] | None = None,
         min_score: float | None = None,
     ) -> list[dict[str, Any]]:
         """
@@ -35,24 +35,20 @@ class RAGRetriever:
         Args:
             query: Query string
             top_k: Number of results to return
-            filter: Optional metadata filter (e.g., {"lesson_number": 1})
+            metadata_filter: Optional metadata filter (e.g., {"lesson_number": 1})
             min_score: Optional minimum similarity score threshold
 
         Returns:
             List of results with text, score, and metadata
         """
-        # Generate query embedding
         query_embedding = self.embedder.embed(query)
 
-        # Query vector database
         response = self.vector_db.query(
-            vector=query_embedding, top_k=top_k, filter=filter, include_metadata=True
+            vector=query_embedding, top_k=top_k, filter=metadata_filter, include_metadata=True
         )
 
-        # Format results
         results = self._format_results(response.get("matches", []))
 
-        # Filter by minimum score if specified
         if min_score is not None:
             results = [r for r in results if r["score"] >= min_score]
 
@@ -61,66 +57,28 @@ class RAGRetriever:
     def retrieve_by_lesson(
         self, query: str, lesson_number: int, top_k: int = 5
     ) -> list[dict[str, Any]]:
-        """
-        Retrieve relevant documents filtered by lesson number.
-
-        Args:
-            query: Query string
-            lesson_number: Lesson number to filter by
-            top_k: Number of results to return
-
-        Returns:
-            List of results from specified lesson
-        """
-        return self.retrieve(query, top_k=top_k, filter={"lesson_number": lesson_number})
+        """Retrieve relevant documents filtered by lesson number."""
+        return self.retrieve(query, top_k=top_k, metadata_filter={"lesson_number": lesson_number})
 
     def retrieve_by_grammar_point(
         self, query: str, grammar_point: str, top_k: int = 5
     ) -> list[dict[str, Any]]:
-        """
-        Retrieve relevant documents filtered by grammar point.
-
-        Args:
-            query: Query string
-            grammar_point: Grammar point to filter by
-            top_k: Number of results to return
-
-        Returns:
-            List of results for specified grammar point
-        """
-        return self.retrieve(query, top_k=top_k, filter={"grammar_point": grammar_point})
+        """Retrieve relevant documents filtered by grammar point."""
+        return self.retrieve(query, top_k=top_k, metadata_filter={"grammar_point": grammar_point})
 
     def retrieve_by_difficulty(
         self, query: str, difficulty: str, top_k: int = 5
     ) -> list[dict[str, Any]]:
-        """
-        Retrieve relevant documents filtered by difficulty level.
-
-        Args:
-            query: Query string
-            difficulty: Difficulty level (beginner, intermediate, advanced)
-            top_k: Number of results to return
-
-        Returns:
-            List of results for specified difficulty
-        """
-        return self.retrieve(query, top_k=top_k, filter={"difficulty": difficulty})
+        """Retrieve relevant documents filtered by difficulty level."""
+        return self.retrieve(query, top_k=top_k, metadata_filter={"difficulty": difficulty})
 
     def _format_results(self, matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """
-        Format raw vector database matches into result objects.
-
-        Args:
-            matches: Raw matches from vector database
-
-        Returns:
-            Formatted results with text, score, and metadata
-        """
+        """Format raw vector database matches into result objects."""
         results = []
         for match in matches:
-            metadata = match.get("metadata", {})
+            original_metadata = match.get("metadata", {})
+            metadata = dict(original_metadata)
 
-            # Extract text from metadata and remove from metadata dict
             text = metadata.pop("text", "")
 
             result = {

--- a/src/rag/rag_retriever.py
+++ b/src/rag/rag_retriever.py
@@ -1,0 +1,133 @@
+"""RAG retrieval interface for querying vector database."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.rag.embedding_model import EmbeddingModel
+from src.rag.vector_database import VectorDatabase
+
+
+class RAGRetriever:
+    """Interface for retrieving relevant documents from vector database."""
+
+    def __init__(self, embedder: EmbeddingModel, vector_db: VectorDatabase):
+        """
+        Initialize RAG retriever.
+
+        Args:
+            embedder: Embedding model for query encoding
+            vector_db: Vector database for similarity search
+        """
+        self.embedder = embedder
+        self.vector_db = vector_db
+
+    def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        filter: dict[str, Any] | None = None,
+        min_score: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Retrieve relevant documents for a query.
+
+        Args:
+            query: Query string
+            top_k: Number of results to return
+            filter: Optional metadata filter (e.g., {"lesson_number": 1})
+            min_score: Optional minimum similarity score threshold
+
+        Returns:
+            List of results with text, score, and metadata
+        """
+        # Generate query embedding
+        query_embedding = self.embedder.embed(query)
+
+        # Query vector database
+        response = self.vector_db.query(
+            vector=query_embedding, top_k=top_k, filter=filter, include_metadata=True
+        )
+
+        # Format results
+        results = self._format_results(response.get("matches", []))
+
+        # Filter by minimum score if specified
+        if min_score is not None:
+            results = [r for r in results if r["score"] >= min_score]
+
+        return results
+
+    def retrieve_by_lesson(
+        self, query: str, lesson_number: int, top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        """
+        Retrieve relevant documents filtered by lesson number.
+
+        Args:
+            query: Query string
+            lesson_number: Lesson number to filter by
+            top_k: Number of results to return
+
+        Returns:
+            List of results from specified lesson
+        """
+        return self.retrieve(query, top_k=top_k, filter={"lesson_number": lesson_number})
+
+    def retrieve_by_grammar_point(
+        self, query: str, grammar_point: str, top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        """
+        Retrieve relevant documents filtered by grammar point.
+
+        Args:
+            query: Query string
+            grammar_point: Grammar point to filter by
+            top_k: Number of results to return
+
+        Returns:
+            List of results for specified grammar point
+        """
+        return self.retrieve(query, top_k=top_k, filter={"grammar_point": grammar_point})
+
+    def retrieve_by_difficulty(
+        self, query: str, difficulty: str, top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        """
+        Retrieve relevant documents filtered by difficulty level.
+
+        Args:
+            query: Query string
+            difficulty: Difficulty level (beginner, intermediate, advanced)
+            top_k: Number of results to return
+
+        Returns:
+            List of results for specified difficulty
+        """
+        return self.retrieve(query, top_k=top_k, filter={"difficulty": difficulty})
+
+    def _format_results(self, matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """
+        Format raw vector database matches into result objects.
+
+        Args:
+            matches: Raw matches from vector database
+
+        Returns:
+            Formatted results with text, score, and metadata
+        """
+        results = []
+        for match in matches:
+            metadata = match.get("metadata", {})
+
+            # Extract text from metadata and remove from metadata dict
+            text = metadata.pop("text", "")
+
+            result = {
+                "text": text,
+                "score": match.get("score", 0.0),
+                "metadata": metadata,
+            }
+            results.append(result)
+
+        return results

--- a/src/rag/sentence_transformer_client.py
+++ b/src/rag/sentence_transformer_client.py
@@ -13,46 +13,22 @@ class SentenceTransformerClient:
         model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
         dimension: int = 384,
     ):
-        """
-        Initialize SentenceTransformer client.
-
-        Args:
-            model_name: HuggingFace model name
-            dimension: Expected embedding dimension
-        """
+        """Initialize SentenceTransformer client."""
         self.model_name = model_name
         self.dimension = dimension
         self.model = SentenceTransformer(model_name)
 
     def embed(self, text: str) -> list[float]:
-        """
-        Generate embedding for a single text.
-
-        Args:
-            text: Text to embed
-
-        Returns:
-            List of floats representing the embedding vector
-        """
+        """Generate embedding for a single text."""
         embeddings = self.model.encode([text], convert_to_numpy=False, show_progress_bar=False)
         embedding = embeddings[0]
 
-        # Normalize to plain Python list
         if hasattr(embedding, "tolist"):
             return embedding.tolist()
         return list(embedding)
 
     def embed_batch(self, texts: list[str], show_progress: bool = False) -> list[list[float]]:
-        """
-        Generate embeddings for multiple texts.
-
-        Args:
-            texts: List of texts to embed
-            show_progress: Show progress bar during embedding
-
-        Returns:
-            List of embedding vectors
-        """
+        """Generate embeddings for multiple texts."""
         if not texts:
             return []
 
@@ -60,14 +36,10 @@ class SentenceTransformerClient:
             texts, convert_to_numpy=False, show_progress_bar=show_progress
         )
 
-        # Convert numpy arrays to lists if needed
-        return embeddings.tolist() if hasattr(embeddings, "tolist") else embeddings
+        if hasattr(embeddings, "tolist"):
+            return embeddings.tolist()
+        return [list(emb) if hasattr(emb, "__iter__") else [emb] for emb in embeddings]
 
     def get_dimension(self) -> int:
-        """
-        Get the dimension of embedding vectors.
-
-        Returns:
-            Embedding dimension
-        """
+        """Get the dimension of embedding vectors."""
         return self.dimension

--- a/src/rag/sentence_transformer_client.py
+++ b/src/rag/sentence_transformer_client.py
@@ -35,7 +35,12 @@ class SentenceTransformerClient:
             List of floats representing the embedding vector
         """
         embeddings = self.model.encode([text], convert_to_numpy=False, show_progress_bar=False)
-        return embeddings[0]
+        embedding = embeddings[0]
+
+        # Normalize to plain Python list
+        if hasattr(embedding, "tolist"):
+            return embedding.tolist()
+        return list(embedding)
 
     def embed_batch(self, texts: list[str], show_progress: bool = False) -> list[list[float]]:
         """

--- a/tests/rag/test_rag_retriever.py
+++ b/tests/rag/test_rag_retriever.py
@@ -1,0 +1,160 @@
+"""Tests for RAG retrieval interface."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.rag.rag_retriever import RAGRetriever
+
+
+class TestRAGRetriever:
+    """Test suite for RAGRetriever."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Fixture for mocked embedding model."""
+        mock = Mock()
+        mock.embed.return_value = [0.5] * 384
+        return mock
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        """Fixture for mocked vector database."""
+        mock = Mock()
+        mock.query.return_value = {
+            "matches": [
+                {
+                    "id": "vec1",
+                    "score": 0.95,
+                    "metadata": {
+                        "text": "Arabic nouns are masculine or feminine.",
+                        "source_file": "lesson_01.md",
+                        "section_title": "Gender",
+                        "lesson_number": 1,
+                    },
+                },
+                {
+                    "id": "vec2",
+                    "score": 0.85,
+                    "metadata": {
+                        "text": "The definite article is ال (al-).",
+                        "source_file": "lesson_01.md",
+                        "section_title": "Definite Article",
+                        "lesson_number": 1,
+                    },
+                },
+            ]
+        }
+        return mock
+
+    def test_retrieve_basic(self, mock_embedder, mock_vector_db):
+        """Test basic retrieval without filters."""
+        retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
+
+        results = retriever.retrieve("What is noun gender?", top_k=2)
+
+        # Verify embedder was called
+        mock_embedder.embed.assert_called_once_with("What is noun gender?")
+
+        # Verify vector_db was called
+        mock_vector_db.query.assert_called_once_with(
+            vector=[0.5] * 384, top_k=2, filter=None, include_metadata=True
+        )
+
+        # Verify results structure
+        assert len(results) == 2
+        assert results[0]["text"] == "Arabic nouns are masculine or feminine."
+        assert results[0]["score"] == 0.95
+        assert results[0]["metadata"]["lesson_number"] == 1
+        assert results[1]["score"] == 0.85
+
+    def test_retrieve_with_filter(self, mock_embedder, mock_vector_db):
+        """Test retrieval with metadata filters."""
+        retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
+
+        retriever.retrieve("test query", top_k=3, filter={"lesson_number": 1})
+
+        # Verify filter was passed to vector_db
+        mock_vector_db.query.assert_called_once()
+        assert mock_vector_db.query.call_args[1]["filter"] == {"lesson_number": 1}
+
+    def test_retrieve_empty_results(self, mock_embedder, mock_vector_db):
+        """Test retrieval when no matches found."""
+        mock_vector_db.query.return_value = {"matches": []}
+
+        retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
+        results = retriever.retrieve("test query")
+
+        assert results == []
+
+    @pytest.mark.parametrize(
+        "method,kwargs,expected_filter",
+        [
+            ("retrieve_by_lesson", {"lesson_number": 1, "top_k": 3}, {"lesson_number": 1}),
+            (
+                "retrieve_by_grammar_point",
+                {"grammar_point": "gender_agreement"},
+                {"grammar_point": "gender_agreement"},
+            ),
+            ("retrieve_by_difficulty", {"difficulty": "beginner"}, {"difficulty": "beginner"}),
+        ],
+    )
+    def test_convenience_filter_methods(
+        self, mock_embedder, mock_vector_db, method, kwargs, expected_filter
+    ):
+        """Test that convenience methods correctly construct filter dicts."""
+        retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
+
+        getattr(retriever, method)("test query", **kwargs)
+
+        mock_vector_db.query.assert_called_once()
+        assert mock_vector_db.query.call_args[1]["filter"] == expected_filter
+
+    def test_format_results(self, mock_embedder, mock_vector_db):
+        """Test result formatting extracts text, score, and metadata."""
+        retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
+
+        results = retriever.retrieve("test query")
+
+        # Results should be formatted with text, score, and metadata
+        assert all("text" in r for r in results)
+        assert all("score" in r for r in results)
+        assert all("metadata" in r for r in results)
+
+        # text should be extracted from metadata
+        assert results[0]["text"] == "Arabic nouns are masculine or feminine."
+
+        # metadata should not contain redundant text field
+        assert "text" not in results[0]["metadata"]
+
+    def test_retrieve_with_min_score(self, mock_embedder, mock_vector_db):
+        """Test filtering results by minimum score threshold."""
+        # Mock results with varying scores
+        mock_vector_db.query.return_value = {
+            "matches": [
+                {
+                    "id": "vec1",
+                    "score": 0.95,
+                    "metadata": {"text": "High relevance", "source_file": "f1.md"},
+                },
+                {
+                    "id": "vec2",
+                    "score": 0.60,
+                    "metadata": {"text": "Medium relevance", "source_file": "f2.md"},
+                },
+                {
+                    "id": "vec3",
+                    "score": 0.30,
+                    "metadata": {"text": "Low relevance", "source_file": "f3.md"},
+                },
+            ]
+        }
+
+        retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
+        results = retriever.retrieve("test query", top_k=10, min_score=0.5)
+
+        # Only results with score >= 0.5 should be returned
+        assert len(results) == 2
+        assert results[0]["score"] == 0.95
+        assert results[1]["score"] == 0.60
+        assert all(r["score"] >= 0.5 for r in results)

--- a/tests/rag/test_rag_retriever.py
+++ b/tests/rag/test_rag_retriever.py
@@ -56,7 +56,6 @@ class TestRAGRetriever:
         # Verify embedder was called
         mock_embedder.embed.assert_called_once_with("What is noun gender?")
 
-        # Verify vector_db was called
         mock_vector_db.query.assert_called_once_with(
             vector=[0.5] * 384, top_k=2, filter=None, include_metadata=True
         )
@@ -72,9 +71,8 @@ class TestRAGRetriever:
         """Test retrieval with metadata filters."""
         retriever = RAGRetriever(embedder=mock_embedder, vector_db=mock_vector_db)
 
-        retriever.retrieve("test query", top_k=3, filter={"lesson_number": 1})
+        retriever.retrieve("test query", top_k=3, metadata_filter={"lesson_number": 1})
 
-        # Verify filter was passed to vector_db
         mock_vector_db.query.assert_called_once()
         assert mock_vector_db.query.call_args[1]["filter"] == {"lesson_number": 1}
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable RAG retrieval interface over the vector database and exercise it against real data and tests.

New Features:
- Add a RAGRetriever class that queries the vector database with optional metadata filters and score threshold, and returns normalized result objects.
- Provide convenience retrieval methods scoped by lesson number, grammar point, and difficulty for RAG queries.
- Add a standalone script to run sample RAG retrievals against a Pinecone index using the sentence-transformer embedder.

Enhancements:
- Normalize single-text embeddings from the sentence-transformer client to plain Python lists for consistent downstream consumption.

Tests:
- Add a comprehensive test suite for RAGRetriever covering basic retrieval, metadata filtering, result formatting, score thresholds, and convenience filter methods.