### PR TITLE
Add simplified lesson 1 v2

### DIFF
--- a/data/rag_database/lessons/lesson_1_v2.md
+++ b/data/rag_database/lessons/lesson_1_v2.md
@@ -1,0 +1,62 @@
+---
+lesson_number: 1
+lesson_name: "Gender and Definite Article"
+grammar_points:
+  - masculine_feminine_nouns
+  - definite_article_al
+prerequisites: []
+difficulty: beginner
+vocabulary:
+  - كِتَابٌ  # kitaabun - book (m)
+  - بَيْتٌ  # baytun - house (m)
+  - قَلَمٌ  # qalamun - pen (m)
+  - طَاوِلَةٌ  # taawilatun - table (f)
+  - مَدْرَسَةٌ  # madrasatun - school (f)
+  - نَافِذَةٌ  # naafidhatun - window (f)
+---
+
+## Vocabulary
+
+1. كِتَابٌ (kitaabun) - book
+2. بَيْتٌ (baytun) - house
+3. قَلَمٌ (qalamun) - pen
+4. طَاوِلَةٌ (taawilatun) - table
+5. مَدْرَسَةٌ (madrasatun) - school
+6. نَافِذَةٌ (naafidhatun) - window
+
+---
+
+## Grammar Point: Masculine and Feminine Nouns
+
+<!-- paragraph:rule -->
+**Rule:** In Arabic, all nouns have a gender - either masculine or feminine. 
+
+For human nouns, the gender matches the person's biological gender. For non-human nouns (objects, places, abstract concepts), the gender is fixed and must be memorized.
+
+Most feminine nouns end with the ة (taa marbuta) marker. Masculine nouns typically don't have this marker.
+<!-- /paragraph:rule -->
+
+<!-- paragraph:agreement -->
+Pronouns, adjectives, and verbs must agree with the gender of the noun they describe or refer to.
+<!-- /paragraph:agreement -->
+
+<!-- paragraph:examples -->
+**Examples:**
+
+Human masculine nouns:
+- رَجُلٌ (rajulun) - man (masculine)
+- وَلَدٌ (waladun) - boy (masculine)
+
+Human feminine nouns:
+- امْرَأَةٌ (imra'atun) - woman (feminine)
+- بِنْتٌ (bintun) - girl (feminine)
+
+Non-human masculine nouns (no ة marker):
+- كِتَابٌ (kitaabun) - book (masculine)
+- بَيْتٌ (baytun) - house (masculine)
+
+Non-human feminine nouns (have ة marker):
+- طَاوِلَةٌ (taawilatun) - table (feminine)
+- مَدْرَسَةٌ (madrasatun) - school (feminine)
+<!-- /paragraph:examples -->
+


### PR DESCRIPTION
- 6 vocabulary words (numbered list format)
- Single grammar point: Masculine and Feminine Nouns
- Organized with paragraph markers for chunking
- Human vs non-human noun examples
- Gender agreement rule included

## Summary by Sourcery

Add a new beginner Arabic lesson covering noun gender and the definite article.

New Features:
- Introduce a new Lesson 1 v2 content file with six core vocabulary nouns split across masculine and feminine genders.
- Document a grammar explanation for masculine vs feminine nouns, including human vs non-human examples and gender agreement notes.

Documentation:
- Add structured markdown lesson content with vocabulary lists and grammar explanations for Arabic noun gender and the definite article.